### PR TITLE
Fix byte padding in hasher

### DIFF
--- a/frost-bluepallas/src/hasher.rs
+++ b/frost-bluepallas/src/hasher.rs
@@ -46,7 +46,8 @@ pub fn hash_to_scalar(input: &[&[u8]]) -> Fq {
 pub fn hash_to_array(input: &[&[u8]]) -> [u8; 32] {
     let scalar = hash_to_scalar(input);
 
+    let bytes_be = scalar.into_bigint().to_bytes_be();
     let mut out = [0u8; 32];
-    out.copy_from_slice(&scalar.into_bigint().to_bytes_be());
+    out[32 - bytes_be.len()..].copy_from_slice(&bytes_be);
     out
 }


### PR DESCRIPTION
## Summary
- fix padding logic in `hash_to_array` so returned arrays are always 32 bytes

## Testing
- `cargo fmt --all -- --check` *(fails: unsuccessful tunnel)*
- `cargo check` *(fails: unsuccessful tunnel)*
- `cargo clippy --all-targets --all-features -- -Dclippy::all -Wclippy::too_many_arguments` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684196c09648832dbb68ef055c43a523