### PR TITLE
feat: interface frost signing with mina verification

### DIFF
--- a/frost-bluepallas/src/lib.rs
+++ b/frost-bluepallas/src/lib.rs
@@ -35,7 +35,7 @@ use crate::hasher::{hash_to_array, hash_to_scalar};
 pub mod keys;
 
 mod hasher;
-mod translate;
+pub mod translate;
 
 #[derive(Clone, Copy)]
 pub struct PallasScalarField;
@@ -82,7 +82,7 @@ pub struct PallasGroup {}
 impl Group for PallasGroup {
     type Element = ProjectivePallas;
     type Field = PallasScalarField;
-    type Serialization = [u8; 32 * 3]; // Projective Pallas is a struct with 3 of PallasScalarField
+    type Serialization = [u8; 32 * 3]; // Projective Pallas is a struct with 3 of PallasBaseField
 
     fn cofactor() -> <Self::Field as Field>::Scalar {
         Self::Field::one()

--- a/frost-bluepallas/src/translate.rs
+++ b/frost-bluepallas/src/translate.rs
@@ -1,22 +1,19 @@
-// Extracting the Element out of the VerifyingKey Struct with some serde magic
-// How to unit test it? Generate a VerifyingKey from a SigningKey from a scalar (arkworks) on the
-//     frost side
-// Do the same on the mina side
-//
-
 use crate::PallasPoseidon;
 use ark_ec::short_weierstrass::{Affine, Projective};
-use frost_core::{Ciphersuite, Group, Signature as FrSig, VerifyingKey};
+use ark_ec::AffineRepr;
+use frost_core::{Ciphersuite, Group, Scalar, Signature as FrSig, VerifyingKey}; // Fr for frost
 use mina_curves::pasta::PallasParameters;
-use mina_signer::{pubkey::PubKey, signature::Signature as MinaSig};
+use mina_signer::{pubkey::PubKey, signature::Signature as MinaSig, NetworkId};
+use mina_hasher::{Hashable, ROInput};
 
 // temporary till we sort out proper error messages
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 // Note
-// CurvePoint = Affine<PallasParameters>                      mina side
-// PallasProjective = Projective<PallasParameters>            frost side
+// CurvePoint = Affine<PallasParameters>                                        mina side
+// PallasProjective = Projective<PallasParameters> (= Element<PallasPoseidon>)  frost side
+// The ScalarField type on the mina and frost side are the same!
 
-fn translate_pk(fr_pk: VerifyingKey<PallasPoseidon>) -> Result<PubKey> {
+pub fn translate_pk(fr_pk: &VerifyingKey<PallasPoseidon>) -> Result<PubKey> {
     // A VerifyingKey is just a group element in some wrapper structs
     // But the api doesn't seem to expose a way to extract the underlying element
     // So I serialize VerifyingKey and deserialize into Element
@@ -35,13 +32,54 @@ fn translate_pk(fr_pk: VerifyingKey<PallasPoseidon>) -> Result<PubKey> {
     Ok(PubKey::from_point_unsafe(pk_affine))
 }
 
-fn translate_sig(fr_sig: FrSig<PallasPoseidon>) -> MinaSig {
-    unimplemented!()
+pub fn translate_sig(fr_sig: &FrSig<PallasPoseidon>) -> Result<MinaSig> {
+    let r: &Projective<PallasParameters> = fr_sig.R();
+    let z: &Scalar<PallasPoseidon> = fr_sig.z();
+    let r_affine: Affine<PallasParameters> = r.clone().into(); // Is this step required?
+    let (rx, _ry) = r_affine
+        .xy()
+        .ok_or("nonce commitment is the point at infinity??!!")?;
+
+    Ok(MinaSig {
+        rx: rx.clone(),
+        s: z.clone(),
+    })
 }
+
+
+
+// This s temporary: it's easier to test that u8 slices as messages work correctly first
+// We can implmement (or reuse) the Hashable trait for transaction as in this example afterwards:
+// https://github.com/o1-labs/proof-systems/blob/master/signer/README.md?plain=1#L19-L40
+
+
+#[derive(Clone, Debug)]
+pub struct PallasMessage (pub Vec<u8>);
+
+// Implement a hashable trait for a u8 slice
+impl Hashable for PallasMessage {
+    type D = NetworkId;
+
+    fn to_roinput(&self) -> ROInput {
+        ROInput::new().append_bytes(self.0.as_ref())
+    }
+
+    // copied from
+    // https://github.com/o1-labs/proof-systems/blob/0.1.0/signer/tests/transaction.rs#L53-L61
+    fn domain_string(network_id: NetworkId) -> Option<String> {
+        // Domain strings must have length <= 20
+        match network_id {
+            NetworkId::MAINNET => "MinaSignatureMainnet",
+            NetworkId::TESTNET =>"FROST-PALLAS-POSEIDON",// "CodaSignature",
+        }
+        .to_string()
+        .into()
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
     use ark_ff::fields::models::fp::{Fp, MontBackend};
     use frost_core::SigningKey;
@@ -54,8 +92,9 @@ mod tests {
         // Then use the translation function to check if it's the same element on both sides
 
         // The type of Scalar from which a SecretKey can be made (on Mina side): Fp<MontBackend<FrConfig, 4>, 4>
-        let n: u32 = 57639753; // generate loads of random n and test
-                               // <PallasParameters as CurveConfig>::ScalarField is the same type as Fp<...>
+        let n: u32 = 57639753; // TODO generate loads of random n and test
+        
+        // <PallasParameters as CurveConfig>::ScalarField is the same type as Fp<...>
         let scalar: Fp<MontBackend<FrConfig, 4>, 4> = Fp::new(n.into());
         let mina_sk = SecKey::new(scalar);
         let mina_pk = PubKey::from_secret_key(mina_sk)?;
@@ -64,7 +103,7 @@ mod tests {
         let fr_sk = SigningKey::from_scalar(scalar)?;
         let fr_pk: VerifyingKey<PallasPoseidon> = fr_sk.into();
 
-        assert_eq!(translate_pk(fr_pk)?, mina_pk);
+        assert_eq!(translate_pk(&fr_pk)?, mina_pk);
         Ok(())
     }
 }

--- a/frost-bluepallas/src/translate.rs
+++ b/frost-bluepallas/src/translate.rs
@@ -3,8 +3,8 @@ use ark_ec::short_weierstrass::{Affine, Projective};
 use ark_ec::AffineRepr;
 use frost_core::{Ciphersuite, Group, Scalar, Signature as FrSig, VerifyingKey}; // Fr for frost
 use mina_curves::pasta::PallasParameters;
-use mina_signer::{pubkey::PubKey, signature::Signature as MinaSig, NetworkId};
 use mina_hasher::{Hashable, ROInput};
+use mina_signer::{pubkey::PubKey, signature::Signature as MinaSig, NetworkId};
 
 // temporary till we sort out proper error messages
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -46,15 +46,12 @@ pub fn translate_sig(fr_sig: &FrSig<PallasPoseidon>) -> Result<MinaSig> {
     })
 }
 
-
-
 // This s temporary: it's easier to test that u8 slices as messages work correctly first
 // We can implmement (or reuse) the Hashable trait for transaction as in this example afterwards:
 // https://github.com/o1-labs/proof-systems/blob/master/signer/README.md?plain=1#L19-L40
 
-
 #[derive(Clone, Debug)]
-pub struct PallasMessage (pub Vec<u8>);
+pub struct PallasMessage(pub Vec<u8>);
 
 // Implement a hashable trait for a u8 slice
 impl Hashable for PallasMessage {
@@ -70,21 +67,23 @@ impl Hashable for PallasMessage {
         // Domain strings must have length <= 20
         match network_id {
             NetworkId::MAINNET => "MinaSignatureMainnet",
-            NetworkId::TESTNET =>"FROST-PALLAS-POSEIDON",// "CodaSignature",
+            NetworkId::TESTNET => "CodaSignature", //"FROST-PALLAS-POSEIDON",
         }
         .to_string()
         .into()
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use ark_ff::fields::models::fp::{Fp, MontBackend};
+    use frost_core as frost;
     use frost_core::SigningKey;
     use mina_curves::pasta::fields::fq::FrConfig;
-    use mina_signer::seckey::SecKey;
+    use mina_signer::{keypair::Keypair, seckey::SecKey, Signer};
+    use std::collections::BTreeMap;
+
     #[test]
     fn test_translate_pk() -> Result<()> {
         // We generate scalars (SecretKey) for both the frost and mina sides in the same way
@@ -93,7 +92,7 @@ mod tests {
 
         // The type of Scalar from which a SecretKey can be made (on Mina side): Fp<MontBackend<FrConfig, 4>, 4>
         let n: u32 = 57639753; // TODO generate loads of random n and test
-        
+
         // <PallasParameters as CurveConfig>::ScalarField is the same type as Fp<...>
         let scalar: Fp<MontBackend<FrConfig, 4>, 4> = Fp::new(n.into());
         let mina_sk = SecKey::new(scalar);
@@ -104,6 +103,80 @@ mod tests {
         let fr_pk: VerifyingKey<PallasPoseidon> = fr_sk.into();
 
         assert_eq!(translate_pk(&fr_pk)?, mina_pk);
+        Ok(())
+    }
+
+    #[test]
+    fn check_hashable_impl() -> Result<()> {
+        // panics if prefix.len() > MAX_DOMAIN_STRING_LEN
+        mina_signer::create_legacy::<PallasMessage>(NetworkId::TESTNET);
+        Ok(())
+    }
+    /// Generate a secret shares using trusted dealer.
+    /// Reconstruct the (joint) secret key for signing using mina-signer
+    /// Sign with frost api using the secret shares
+    /// Check if the signatures coincide using the `translate_sig` function
+    #[test]
+    fn test_translate_sig() -> Result<()> {
+        let mut rng = rand_core::OsRng;
+
+        // Generate a secret shares using the frost api
+
+        let max_signers = 5;
+        let min_signers = 3;
+        let (shares, pubkeys) = frost::keys::generate_with_dealer(
+            max_signers,
+            min_signers,
+            frost::keys::IdentifierList::Default,
+            &mut rng,
+        )
+        .unwrap();
+
+        let mut key_packages: BTreeMap<
+            frost::Identifier<PallasPoseidon>,
+            frost::keys::KeyPackage<PallasPoseidon>,
+        > = BTreeMap::new();
+
+        for (k, v) in shares {
+            let key_package = frost::keys::KeyPackage::try_from(v).unwrap();
+            key_packages.insert(k, key_package);
+        }
+
+        // sign with frost
+
+        let (fr_msg, fr_sig, fr_pk) = frost::tests::ciphersuite_generic::check_sign(
+            min_signers,
+            key_packages.clone(),
+            rng,
+            pubkeys,
+        )
+        .unwrap();
+
+        // sign with mina
+
+        let fr_sk = frost::keys::reconstruct(
+            key_packages
+                .values()
+                .map(|x| x.clone())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )?;
+
+        let mina_sk = SecKey::new(fr_sk.to_scalar());
+        // for some reason the mina `sign` function takes public key as well
+        let mina_keypair: Keypair = Keypair {
+            secret: mina_sk,
+            public: translate_pk(&fr_pk)?,
+        };
+
+        let mina_msg = PallasMessage(fr_msg.clone());
+
+        let mut ctx = mina_signer::create_legacy::<PallasMessage>(NetworkId::TESTNET);
+        let mina_sig = ctx.sign(&mina_keypair, &mina_msg);
+
+        // compare
+
+        assert_eq!(mina_sig, translate_sig(&fr_sig)?);
         Ok(())
     }
 }

--- a/frost-bluepallas/tests/mina_compatibility.rs
+++ b/frost-bluepallas/tests/mina_compatibility.rs
@@ -1,0 +1,22 @@
+use frost_core as frost;
+use frost_bluepallas::{PallasPoseidon, 
+    translate::{translate_pk, translate_sig, PallasMessage},
+};
+
+use mina_signer::{NetworkId, Signer};
+
+#[test]
+fn frost_sign_mina_verify() -> Result<(), Box<dyn std::error::Error>> {
+    let rng = rand_core::OsRng;
+
+    let (fr_msg, fr_sig, fr_pk) = frost::tests::ciphersuite_generic::check_sign_with_dealer::<PallasPoseidon, _>(
+        rng
+    );
+    let mina_pk = translate_pk(&fr_pk)?;
+    let mina_sig = translate_sig(&fr_sig)?;
+    let mina_msg = PallasMessage(fr_msg.clone());
+
+    let mut ctx = mina_signer::create_legacy::<PallasMessage>(NetworkId::TESTNET);
+    assert!(ctx.verify(&mina_sig, &mina_pk, &mina_msg));
+    Ok(())
+}


### PR DESCRIPTION
The previous MR dealt with translation of public keys.

Here we deal with translation of signatures and messages from frost land to mina land. And also the actual test which checks whether frost generated signatures are verified by mina_signer. Currently it fails.

Translation of signatures is relatively straightforward. Project coordinates are converted to affine and then the x coordinate is dropped. But there's no unit test for this function yet.

Messages need to be `Hashable` (Mina trait), to be verified by mina. Ultimately we'd want this message to be a transaction for a full POC, but for now it's easier to work with byte sequences.