### PR TITLE
Mina Tx Tests

### DIFF
--- a/frost-bluepallas/Cargo.toml
+++ b/frost-bluepallas/Cargo.toml
@@ -16,5 +16,5 @@ rand_core = { version = "0.6.4", features = ["getrandom"] }
 #rand_core.workspace = true
 
 [dev-dependencies]
-frost-core = { version = "2.1.0", features = ["test-impl"] }
+frost-core = { version = "2.1.0", features = ["test-impl", "internals"] }
 rand_chacha = "0.3"

--- a/frost-bluepallas/src/keys.rs
+++ b/frost-bluepallas/src/keys.rs
@@ -76,13 +76,7 @@ pub fn split<R: RngCore + CryptoRng>(
     identifiers: IdentifierList,
     rng: &mut R,
 ) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
-    Ok(into_even_y(frost::keys::split(
-        key,
-        max_signers,
-        min_signers,
-        identifiers,
-        rng,
-    )?))
+    frost::keys::split(key, max_signers, min_signers, identifiers, rng).map(into_even_y)
 }
 
 /// Copied from https://github.com/ZcashFoundation/reddsa/blob/main/src/frost/redpallas.rs

--- a/frost-bluepallas/src/keys.rs
+++ b/frost-bluepallas/src/keys.rs
@@ -4,7 +4,7 @@ use ark_ff::{BigInteger, PrimeField};
 use frost_core::{self as frost, keys::CoefficientCommitment};
 use rand_core::{CryptoRng, RngCore};
 
-use crate::{Error, Identifier, VerifyingKey, P};
+use crate::{Error, Identifier, SigningKey, VerifyingKey, P};
 
 pub mod dkg;
 
@@ -61,6 +61,28 @@ pub fn generate_with_dealer<RNG: RngCore + CryptoRng>(
 ) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
     frost::keys::generate_with_dealer(max_signers, min_signers, identifiers, &mut rng)
         .map(into_even_y)
+}
+
+/// Splits an existing key into FROST shares.
+///
+/// This is identical to [`generate_with_dealer`] but receives an existing key
+/// instead of generating a fresh one. This is useful in scenarios where
+/// the key needs to be generated externally or must be derived from e.g. a
+/// seed phrase.
+pub fn split<R: RngCore + CryptoRng>(
+    key: &SigningKey,
+    max_signers: u16,
+    min_signers: u16,
+    identifiers: IdentifierList,
+    rng: &mut R,
+) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
+    Ok(into_even_y(frost::keys::split(
+        key,
+        max_signers,
+        min_signers,
+        identifiers,
+        rng,
+    )?))
 }
 
 /// Copied from https://github.com/ZcashFoundation/reddsa/blob/main/src/frost/redpallas.rs

--- a/frost-bluepallas/src/negate.rs
+++ b/frost-bluepallas/src/negate.rs
@@ -1,0 +1,82 @@
+use frost_core::{
+    round1::{Nonce, NonceCommitment},
+    Group,
+};
+
+use crate::{
+    round1::{SigningCommitments, SigningNonces},
+    PallasGroup, PallasPoseidon, SigningPackage,
+};
+
+/// This trait is used to negate the Y coordinate of the group commitment element with FROST
+/// This is achieved by negating all nonces and commitments produced by all participants
+pub(crate) trait NegateY {
+    /// Negate the Y coordinate of the group element
+    fn negate_y(&self) -> Self;
+}
+
+impl NegateY for SigningNonces {
+    fn negate_y(&self) -> Self {
+        let negated_hiding = -self.hiding().to_scalar();
+        let negated_binding = -self.binding().to_scalar();
+        SigningNonces::from_nonces(
+            Nonce::<PallasPoseidon>::from_scalar(negated_hiding),
+            Nonce::<PallasPoseidon>::from_scalar(negated_binding),
+        )
+    }
+}
+
+impl NegateY for SigningCommitments {
+    fn negate_y(&self) -> Self {
+        // Perform serialization roundtrip to get the hiding and binding parts
+        let hiding_commitment_ser: <PallasGroup as frost_core::Group>::Serialization = self
+            .hiding()
+            .serialize()
+            .unwrap()
+            .as_slice()
+            .try_into()
+            .expect("Hiding commitment should be 96 bytes long");
+
+        // Deserialize the hiding commitment to get the group element
+        let hiding_commitment = PallasGroup::deserialize(&hiding_commitment_ser)
+            .expect("Failed to deserialize hiding commitment");
+
+        // Perform the same for the binding commitment
+        let binding_commitment_ser: <PallasGroup as frost_core::Group>::Serialization = self
+            .binding()
+            .serialize()
+            .unwrap()
+            .as_slice()
+            .try_into()
+            .expect("Binding commitment should be 32 bytes long");
+        let binding_commitment = PallasGroup::deserialize(&binding_commitment_ser)
+            .expect("Failed to deserialize binding commitment");
+
+        // Negate the commitments and serialize/deserialize roundtrip
+        let negated_hiding = -hiding_commitment;
+        let negated_binding = -binding_commitment;
+
+        // Create a new SigningCommitments instance with the negated values
+        let negated_hiding_nonce =
+            NoncePallas::deserialize(&<PallasGroup as Group>::serialize(&negated_hiding).unwrap())
+                .unwrap();
+        let negated_binding_nonce =
+            NoncePallas::deserialize(&<PallasGroup as Group>::serialize(&negated_binding).unwrap())
+                .unwrap();
+
+        SigningCommitments::new(negated_hiding_nonce, negated_binding_nonce)
+    }
+}
+
+type NoncePallas = NonceCommitment<PallasPoseidon>;
+
+impl NegateY for SigningPackage {
+    fn negate_y(&self) -> Self {
+        let negated_commitments = self
+            .signing_commitments()
+            .iter()
+            .map(|(id, commitment)| (*id, commitment.negate_y()))
+            .collect();
+        SigningPackage::new(negated_commitments, self.message())
+    }
+}

--- a/frost-bluepallas/tests/frost-bluepallas.rs
+++ b/frost-bluepallas/tests/frost-bluepallas.rs
@@ -367,4 +367,96 @@ mod tests {
             rng,
         );
     }
+
+    #[allow(clippy::needless_borrows_for_generic_args)]
+    #[test]
+    fn check_sign_with_frost_bluepallas_sign() {
+        let mut rng = rand_core::OsRng;
+        let max_signers = 5;
+        let min_signers = 3;
+        let (shares, pubkey_package) = frost_bluepallas::keys::generate_with_dealer(
+            max_signers,
+            min_signers,
+            frost_bluepallas::keys::IdentifierList::Default,
+            &mut rng,
+        )
+        .unwrap();
+
+        // Verifies the secret shares from the dealer and store them in a BTreeMap.
+        // In practice, the KeyPackages must be sent to its respective participants
+        // through a confidential and authenticated channel.
+        let mut key_packages: BTreeMap<_, _> = BTreeMap::new();
+
+        for (identifier, secret_share) in shares {
+            let key_package = frost_bluepallas::keys::KeyPackage::try_from(secret_share).unwrap();
+            key_packages.insert(identifier, key_package);
+        }
+
+        let mut nonces_map = BTreeMap::new();
+        let mut commitments_map = BTreeMap::new();
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Round 1: generating nonces and signing commitments for each participant
+        ////////////////////////////////////////////////////////////////////////////
+
+        // In practice, each iteration of this loop will be executed by its respective participant.
+        for participant_index in 1..=min_signers {
+            let participant_identifier = participant_index.try_into().expect("should be nonzero");
+            let key_package = &key_packages[&participant_identifier];
+            // Generate one (1) nonce and one SigningCommitments instance for each
+            // participant, up to _threshold_.
+            let (nonces, commitments) =
+                frost_bluepallas::round1::commit(key_package.signing_share(), &mut rng);
+            // In practice, the nonces must be kept by the participant to use in the
+            // next round, while the commitment must be sent to the coordinator
+            // (or to every other participant if there is no coordinator) using
+            // an authenticated channel.
+            nonces_map.insert(participant_identifier, nonces);
+            commitments_map.insert(participant_identifier, commitments);
+        }
+
+        // This is what the signature aggregator / coordinator needs to do:
+        // - decide what message to sign
+        // - take one (unused) commitment per signing participant
+        let mut signature_shares = BTreeMap::new();
+        let message = "message to sign".as_bytes();
+        let signing_package = frost_bluepallas::SigningPackage::new(commitments_map, message);
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Round 2: each participant generates their signature share
+        ////////////////////////////////////////////////////////////////////////////
+
+        // In practice, each iteration of this loop will be executed by its respective participant.
+        for participant_identifier in nonces_map.keys() {
+            let key_package = &key_packages[participant_identifier];
+
+            let nonces = &nonces_map[participant_identifier];
+
+            // Each participant generates their signature share.
+            let signature_share =
+                frost_bluepallas::round2::sign(&signing_package, nonces, key_package).unwrap();
+
+            // In practice, the signature share must be sent to the Coordinator
+            // using an authenticated channel.
+            signature_shares.insert(*participant_identifier, signature_share);
+        }
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Aggregation: collects the signing shares from all participants,
+        // generates the final signature.
+        ////////////////////////////////////////////////////////////////////////////
+
+        // Aggregate (also verifies the signature shares)
+        let group_signature =
+            frost_bluepallas::aggregate(&signing_package, &signature_shares, &pubkey_package)
+                .unwrap();
+
+        // Check that the threshold signature can be verified by the group public
+        // key (the verification key).
+        let is_signature_valid = pubkey_package
+            .verifying_key()
+            .verify(message, &group_signature)
+            .is_ok();
+        assert!(is_signature_valid);
+    }
 }

--- a/frost-bluepallas/tests/mina_compatibility.rs
+++ b/frost-bluepallas/tests/mina_compatibility.rs
@@ -21,7 +21,7 @@ mod helper;
 fn frost_sign_mina_verify() -> Result<(), Box<dyn std::error::Error>> {
     // Esnure that the FROST implementation can sign a message and Mina can verify it
 
-    let rng = rand_chacha::ChaChaRng::seed_from_u64(1);
+    let rng = rand_chacha::ChaChaRng::seed_from_u64(100);
     let fr_msg = b"Test message for FROST and Mina compatibility".to_vec();
 
     let (fr_sig, fr_pk) = generate_signature_random(&fr_msg, rng)?;

--- a/frost-bluepallas/tests/mina_compatibility.rs
+++ b/frost-bluepallas/tests/mina_compatibility.rs
@@ -21,7 +21,7 @@ mod helper;
 fn frost_sign_mina_verify() -> Result<(), Box<dyn std::error::Error>> {
     // Esnure that the FROST implementation can sign a message and Mina can verify it
 
-    let rng = rand_chacha::ChaChaRng::seed_from_u64(0);
+    let rng = rand_chacha::ChaChaRng::seed_from_u64(1);
     let fr_msg = b"Test message for FROST and Mina compatibility".to_vec();
 
     let (fr_sig, fr_pk) = generate_signature_random(&fr_msg, rng)?;

--- a/frost-bluepallas/tests/mina_compatibility.rs
+++ b/frost-bluepallas/tests/mina_compatibility.rs
@@ -99,3 +99,26 @@ fn frost_sign_mina_verify() -> Result<(), Box<dyn std::error::Error>> {
     assert!(ctx.verify(&mina_sig, &mina_pk, &mina_msg));
     Ok(())
 }
+
+#[test]
+fn frost_even_commitment() {
+    // Iterate 32 times to ensure we have at least one even commitment
+    for i in 0..32 {
+        let rng = rand_chacha::ChaChaRng::seed_from_u64(i);
+        let fr_msg = b"Test message for FROST even commitment".to_vec();
+        let (fr_sig, _fr_pk) =
+            generate_signature_random(&fr_msg, rng).expect("Failed to generate signature");
+
+        // Ensure the signature commitment y-coordinate is even
+        assert!(
+            fr_sig
+                .R()
+                .into_affine()
+                .y()
+                .expect("Failed to extract y-coord from sig")
+                .into_bigint()
+                .is_even(),
+            "Signature commitment y-coordinate must be even"
+        );
+    }
+}

--- a/frost-bluepallas/tests/mina_compatibility.rs
+++ b/frost-bluepallas/tests/mina_compatibility.rs
@@ -13,7 +13,7 @@ use rand_core::SeedableRng;
 
 use std::ops::{Add, Neg};
 
-use crate::helper::generate_signature;
+use crate::helper::generate_signature_random;
 
 mod helper;
 
@@ -22,8 +22,9 @@ fn frost_sign_mina_verify() -> Result<(), Box<dyn std::error::Error>> {
     // Esnure that the FROST implementation can sign a message and Mina can verify it
 
     let rng = rand_chacha::ChaChaRng::seed_from_u64(0);
+    let fr_msg = b"Test message for FROST and Mina compatibility".to_vec();
 
-    let (fr_msg, fr_sig, fr_pk) = generate_signature(rng)?;
+    let (fr_sig, fr_pk) = generate_signature_random(&fr_msg, rng)?;
 
     assert!(
         fr_sig

--- a/frost-bluepallas/tests/mina_tests/mod.rs
+++ b/frost-bluepallas/tests/mina_tests/mod.rs
@@ -1,0 +1,3 @@
+#![cfg(test)]
+pub mod signer;
+mod transactions;

--- a/frost-bluepallas/tests/mina_tests/signer.rs
+++ b/frost-bluepallas/tests/mina_tests/signer.rs
@@ -1,0 +1,111 @@
+use crate::{helper, mina_tests::transactions::Transaction};
+use frost_bluepallas::{
+    hasher::PallasMessage,
+    translate::{translate_minask, translate_msg, translate_pk},
+};
+use mina_signer::{Keypair, NetworkId, PubKey, Signer};
+use rand_core::SeedableRng;
+
+#[cfg(test)]
+#[test]
+fn signer_test_raw() {
+    let kp = Keypair::from_hex("164244176fddb5d769b7de2027469d027ad428fadcc0c02396e6280142efb718")
+        .expect("failed to create keypair");
+    let tx = Transaction::new_payment(
+        kp.public.clone(),
+        PubKey::from_address("B62qicipYxyEHu7QjUqS7QvBipTs5CzgkYZZZkPoKVYBu6tnDUcE9Zt")
+            .expect("invalid address"),
+        1729000000000,
+        2000000000,
+        16,
+    )
+    .set_valid_until(271828)
+    .set_memo_str("Hello Mina!");
+
+    assert_eq!(tx.valid_until, 271828);
+    assert_eq!(
+        tx.memo,
+        [
+            0x01, 0x0b, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x4d, 0x69, 0x6e, 0x61, 0x21, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ]
+    );
+
+    // Generate FROST signature using the private key
+    let msg = translate_msg(&tx);
+    let fr_sk =
+        translate_minask(&kp).expect("failed to translate mina keypair to frost signing key");
+
+    let (sig, vk) = helper::generate_signature_from_sk(&msg, &fr_sk, rand_core::OsRng)
+        .expect("failed to generate FROST signature");
+
+    // Convert signature to Mina format
+    let mina_sig = frost_bluepallas::translate::translate_sig(&sig)
+        .expect("failed to translate FROST signature to Mina signature");
+
+    // Convert verifying key to Mina format
+    let mina_vk = frost_bluepallas::translate::translate_pk(&vk)
+        .expect("failed to translate FROST verifying key to Mina public key");
+
+    // Verify that vk from FROST and Mina matches
+    let frost_addr = mina_vk.into_address();
+    let mina_addr = kp.public.into_address();
+    assert_eq!(
+        frost_addr, mina_addr,
+        "FROST verifying key address does not match Mina public key address"
+    );
+
+    // Create ctx signer and verify the signature
+    let mut ctx = mina_signer::create_legacy(NetworkId::TESTNET);
+    let is_valid = ctx.verify(&mina_sig, &mina_vk, &PallasMessage(msg.clone()));
+
+    assert!(is_valid, "Mina signature verification failed");
+}
+
+#[test]
+fn sign_mina_tx() {
+    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(0);
+    // Use trusted dealer to setup public and packages
+    let max_signers = 5;
+    let min_signers = 3;
+    let (shares, pubkey_package) = frost_bluepallas::keys::generate_with_dealer(
+        max_signers,
+        min_signers,
+        frost_bluepallas::keys::IdentifierList::Default,
+        &mut rng,
+    )
+    .expect("Failed to generate key shares");
+
+    // Convert pubkey package to Mina format
+
+    // Create a transaction
+    let tx = Transaction::new_payment(
+        translate_pk(pubkey_package.verifying_key())
+            .expect("failed to translate verifying key to Mina public key"),
+        PubKey::from_address("B62qicipYxyEHu7QjUqS7QvBipTs5CzgkYZZZkPoKVYBu6tnDUcE9Zt")
+            .expect("invalid address"),
+        1729000000000,
+        2000000000,
+        16,
+    )
+    .set_valid_until(271828)
+    .set_memo_str("Hello Mina!");
+
+    // Generate FROST signature
+    let msg = translate_msg(&tx);
+    let (sig, vk) = helper::sign_from_packages(&msg, shares, pubkey_package, &mut rng)
+        .expect("Failed to sign message with FROST");
+
+    // Verify the signature
+    let mina_sig = frost_bluepallas::translate::translate_sig(&sig)
+        .expect("Failed to translate FROST signature to Mina signature");
+    let mina_vk = frost_bluepallas::translate::translate_pk(&vk)
+        .expect("Failed to translate FROST verifying key to Mina public key");
+
+    // Verify the signature using Mina Signer
+    let mut ctx = mina_signer::create_legacy(NetworkId::TESTNET);
+    let is_valid = ctx.verify(&mina_sig, &mina_vk, &PallasMessage(msg.clone()));
+
+    assert!(is_valid, "Mina signature verification failed");
+}

--- a/frost-bluepallas/tests/mina_tests/signer.rs
+++ b/frost-bluepallas/tests/mina_tests/signer.rs
@@ -1,14 +1,18 @@
+#![allow(clippy::needless_borrows_for_generic_args)]
+
 use crate::{helper, mina_tests::transactions::Transaction};
 use frost_bluepallas::{
-    hasher::PallasMessage,
+    hasher::{set_network_id, PallasMessage},
     translate::{translate_minask, translate_msg, translate_pk},
 };
+use frost_core::Ciphersuite;
 use mina_signer::{Keypair, NetworkId, PubKey, Signer};
-use rand_core::SeedableRng;
 
 #[cfg(test)]
 #[test]
 fn signer_test_raw() {
+    set_network_id(NetworkId::TESTNET).expect("Failed to set network ID");
+
     let kp = Keypair::from_hex("164244176fddb5d769b7de2027469d027ad428fadcc0c02396e6280142efb718")
         .expect("failed to create keypair");
     let tx = Transaction::new_payment(
@@ -65,7 +69,8 @@ fn signer_test_raw() {
 
 #[test]
 fn sign_mina_tx() {
-    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(0);
+    let mut rng = rand_core::OsRng;
+
     // Use trusted dealer to setup public and packages
     let max_signers = 5;
     let min_signers = 3;
@@ -108,4 +113,56 @@ fn sign_mina_tx() {
     let is_valid = ctx.verify(&mina_sig, &mina_vk, &PallasMessage(msg.clone()));
 
     assert!(is_valid, "Mina signature verification failed");
+}
+
+#[test]
+fn sign_mina_tx_mainnet() {
+    let mut rng = rand_core::OsRng;
+
+    // Set network id to Mainnet
+    set_network_id(NetworkId::MAINNET).expect("Failed to set network ID");
+
+    // Use trusted dealer to setup public and packages
+    let max_signers = 3;
+    let min_signers = 2;
+    let (shares, pubkey_package) = frost_bluepallas::keys::generate_with_dealer(
+        max_signers,
+        min_signers,
+        frost_bluepallas::keys::IdentifierList::Default,
+        &mut rng,
+    )
+    .expect("Failed to generate key shares");
+
+    // Create a transaction for mainnet
+    let tx = Transaction::new_payment(
+        translate_pk(pubkey_package.verifying_key())
+            .expect("failed to translate verifying key to Mina public key"),
+        PubKey::from_address("B62qicipYxyEHu7QjUqS7QvBipTs5CzgkYZZZkPoKVYBu6tnDUcE9Zt")
+            .expect("invalid address"),
+        1500000000000, // Different amount
+        1000000000,    // Different fee
+        10,            // Different nonce
+    )
+    .set_valid_until(300000)
+    .set_memo_str("Mainnet Test!");
+
+    // Generate FROST signature
+    let msg = translate_msg(&tx);
+    let (sig, vk) = helper::sign_from_packages(&msg, shares, pubkey_package, &mut rng)
+        .expect("Failed to sign message with FROST");
+
+    let _chall = frost_bluepallas::PallasPoseidon::challenge(sig.R(), &vk, &msg)
+        .expect("Expect challenge to calculate");
+
+    // Convert signature to Mina format
+    let mina_sig = frost_bluepallas::translate::translate_sig(&sig)
+        .expect("Failed to translate FROST signature to Mina signature");
+    let mina_vk = frost_bluepallas::translate::translate_pk(&vk)
+        .expect("Failed to translate FROST verifying key to Mina public key");
+
+    // Verify the signature using Mina Signer with MAINNET
+    let mut ctx = mina_signer::create_legacy(NetworkId::MAINNET);
+    let is_valid = ctx.verify(&mina_sig, &mina_vk, &PallasMessage(msg.clone()));
+
+    assert!(is_valid, "Mina signature verification failed on MAINNET");
 }

--- a/frost-bluepallas/tests/mina_tests/transactions.rs
+++ b/frost-bluepallas/tests/mina_tests/transactions.rs
@@ -1,0 +1,125 @@
+#![allow(dead_code)]
+use mina_hasher::{Hashable, ROInput};
+use mina_signer::{CompressedPubKey, NetworkId, PubKey};
+
+/// Copied from https://github.com/o1-labs/proof-systems/blob/master/signer/tests/transaction.rs
+const MEMO_BYTES: usize = 34;
+const TAG_BITS: usize = 3;
+const PAYMENT_TX_TAG: [bool; TAG_BITS] = [false, false, false];
+const DELEGATION_TX_TAG: [bool; TAG_BITS] = [false, false, true];
+
+#[derive(Clone)]
+pub struct Transaction {
+    // Common
+    pub fee: u64,
+    pub fee_token: u64,
+    pub fee_payer_pk: CompressedPubKey,
+    pub nonce: u32,
+    pub valid_until: u32,
+    pub memo: [u8; MEMO_BYTES],
+    // Body
+    pub tag: [bool; TAG_BITS],
+    pub source_pk: CompressedPubKey,
+    pub receiver_pk: CompressedPubKey,
+    pub token_id: u64,
+    pub amount: u64,
+    pub token_locked: bool,
+}
+
+impl Hashable for Transaction {
+    type D = NetworkId;
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new()
+            .append_field(self.fee_payer_pk.x)
+            .append_field(self.source_pk.x)
+            .append_field(self.receiver_pk.x)
+            .append_u64(self.fee)
+            .append_u64(self.fee_token)
+            .append_bool(self.fee_payer_pk.is_odd)
+            .append_u32(self.nonce)
+            .append_u32(self.valid_until)
+            .append_bytes(&self.memo);
+
+        for tag_bit in self.tag {
+            roi = roi.append_bool(tag_bit);
+        }
+
+        roi.append_bool(self.source_pk.is_odd)
+            .append_bool(self.receiver_pk.is_odd)
+            .append_u64(self.token_id)
+            .append_u64(self.amount)
+            .append_bool(self.token_locked)
+    }
+
+    fn domain_string(network_id: NetworkId) -> Option<String> {
+        // Domain strings must have length <= 20
+        match network_id {
+            NetworkId::MAINNET => "MinaSignatureMainnet",
+            NetworkId::TESTNET => "CodaSignature",
+        }
+        .to_string()
+        .into()
+    }
+}
+
+impl Transaction {
+    pub fn new_payment(from: PubKey, to: PubKey, amount: u64, fee: u64, nonce: u32) -> Self {
+        Transaction {
+            fee,
+            fee_token: 1,
+            fee_payer_pk: from.into_compressed(),
+            nonce,
+            valid_until: u32::MAX,
+            memo: core::array::from_fn(|i| (i == 0) as u8),
+            tag: PAYMENT_TX_TAG,
+            source_pk: from.into_compressed(),
+            receiver_pk: to.into_compressed(),
+            token_id: 1,
+            amount,
+            token_locked: false,
+        }
+    }
+
+    pub fn new_delegation(from: PubKey, to: PubKey, fee: u64, nonce: u32) -> Self {
+        Transaction {
+            fee,
+            fee_token: 1,
+            fee_payer_pk: from.into_compressed(),
+            nonce,
+            valid_until: u32::MAX,
+            memo: core::array::from_fn(|i| (i == 0) as u8),
+            tag: DELEGATION_TX_TAG,
+            source_pk: from.into_compressed(),
+            receiver_pk: to.into_compressed(),
+            token_id: 1,
+            amount: 0,
+            token_locked: false,
+        }
+    }
+
+    pub fn set_valid_until(mut self, global_slot: u32) -> Self {
+        self.valid_until = global_slot;
+
+        self
+    }
+
+    pub fn set_memo(mut self, memo: [u8; MEMO_BYTES - 2]) -> Self {
+        self.memo[0] = 0x01;
+        self.memo[1] = (MEMO_BYTES - 2) as u8;
+        self.memo[2..].copy_from_slice(&memo[..]);
+
+        self
+    }
+
+    pub fn set_memo_str(mut self, memo: &str) -> Self {
+        self.memo[0] = 0x01;
+        self.memo[1] = core::cmp::min(memo.len(), MEMO_BYTES - 2) as u8;
+        let memo = format!("{memo:\0<32}"); // Pad user-supplied memo with zeros
+        self.memo[2..]
+            .copy_from_slice(&memo.as_bytes()[..core::cmp::min(memo.len(), MEMO_BYTES - 2)]);
+        // Anything beyond MEMO_BYTES is truncated
+
+        self
+    }
+}

--- a/frost-bluepallas/tests/mod.rs
+++ b/frost-bluepallas/tests/mod.rs
@@ -1,0 +1,3 @@
+#![cfg(test)]
+pub mod helper;
+mod mina_tests;


### PR DESCRIPTION
Write Mina transactional tests in order to ensure that FROST produces valid Mina signatures for Mina transaction structures.

Implement `NegateY` struct for `SigningPackage` and `SigningNonces` to ensure that all group commitments produced within FROST have even Y coordinates. Add `pre_commit_sign` and `pre_commit_aggregate` hooks to `sign` and `aggregate` respectively to change group commitment values if necessary. 

As the hashing and challenge functions within are static, I have used thread_local storage to allow modification of the NetworkId between Mainnet and Testnet transactions.

TODO:
Find a better way of modifying NetworkId for FROST signing.