### PR TITLE
Update contact prefix to minafrost

### DIFF
--- a/frost-client/examples/dkg_example/dkg_example.sh
+++ b/frost-client/examples/dkg_example/dkg_example.sh
@@ -96,15 +96,15 @@ echo "========================================="
 echo "Generating contact strings..."
 
 echo "Generating Alice's contact..."
-ALICE_CONTACT=$(cargo run --bin frost-client -- export --name 'Alice' -c "$GENERATED_DIR/alice.toml" 2>&1 | grep "^zffrost" || true)
+ALICE_CONTACT=$(cargo run --bin frost-client -- export --name 'Alice' -c "$GENERATED_DIR/alice.toml" 2>&1 | grep "^minafrost" || true)
 echo "Alice's contact: '$ALICE_CONTACT'"
 
 echo "Generating Bob's contact..."
-BOB_CONTACT=$(cargo run --bin frost-client -- export --name 'Bob' -c "$GENERATED_DIR/bob.toml" 2>&1 | grep "^zffrost" || true)
+BOB_CONTACT=$(cargo run --bin frost-client -- export --name 'Bob' -c "$GENERATED_DIR/bob.toml" 2>&1 | grep "^minafrost" || true)
 echo "Bob's contact: '$BOB_CONTACT'"
 
 echo "Generating Eve's contact..."
-EVE_CONTACT=$(cargo run --bin frost-client -- export --name 'Eve' -c "$GENERATED_DIR/eve.toml" 2>&1 | grep "^zffrost" || true)
+EVE_CONTACT=$(cargo run --bin frost-client -- export --name 'Eve' -c "$GENERATED_DIR/eve.toml" 2>&1 | grep "^minafrost" || true)
 echo "Eve's contact: '$EVE_CONTACT'"
 
 echo ""

--- a/frost-client/src/cli/contact.rs
+++ b/frost-client/src/cli/contact.rs
@@ -1,5 +1,8 @@
 use std::error::Error;
 
+/// Human readable part used when encoding/decoding contact strings.
+const CONTACT_HRP: &str = "minafrost";
+
 use crate::cipher::PublicKey;
 use eyre::{eyre, OptionExt};
 use serde::{Deserialize, Serialize};
@@ -33,14 +36,14 @@ impl Contact {
     /// Returns the contact encoded as a text string, with Bech32.
     pub fn as_text(&self) -> Result<String, Box<dyn Error>> {
         let bytes = postcard::to_allocvec(self)?;
-        let hrp = bech32::Hrp::parse("zffrost").expect("valid hrp");
+        let hrp = bech32::Hrp::parse(CONTACT_HRP).expect("valid hrp");
         Ok(bech32::encode::<bech32::Bech32m>(hrp, &bytes)?)
     }
 
     /// Creates a Contact from the given encoded text string.
     pub fn from_text(s: &str) -> Result<Self, Box<dyn Error>> {
         let (hrp, bytes) = bech32::decode(s)?;
-        if hrp.as_str() != "zffrost" {
+        if hrp.as_str() != CONTACT_HRP {
             return Err(eyre!("invalid contact format").into());
         }
         let contact: Contact = postcard::from_bytes(&bytes)?;


### PR DESCRIPTION
## Summary
- update HRP for FROST contact strings to `minafrost`
- adjust DKG example script to search for the new prefix

## Testing
- `cargo clippy --all-targets --all-features -- -D clippy::all -W clippy::too_many_arguments`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_688c89ea634c832d8cbc1d4707c29cc6