### PR TITLE
Add network abstraction

### DIFF
--- a/frost-bluepallas/README.md
+++ b/frost-bluepallas/README.md
@@ -46,11 +46,10 @@ frost-bluepallas = { git = "https://github.com/Raspberry-Devs/mina-multi-sig" }
 ### Basic Usage with Trusted Dealer
 
 ```rust
-use frost_bluepallas::{self as frost, hasher::set_network_id};
-use mina_signer::NetworkId;
+use frost_bluepallas::{self as frost, hasher::set_network_testnet};
 
-// Set network (TESTNET or MAINNET)
-set_network_id(NetworkId::TESTNET)?;
+// Set network (TESTNET)
+set_network_testnet()?;
 
 // Generate key shares using trusted dealer
 let max_signers = 5;
@@ -149,14 +148,13 @@ cargo run --example mina-sign-tx
 Set the network ID before signing:
 
 ```rust
-use frost_bluepallas::hasher::set_network_id;
-use mina_signer::NetworkId;
+use frost_bluepallas::hasher::{set_network_mainnet, set_network_testnet};
 
 // For Testnet
-set_network_id(NetworkId::TESTNET)?;
+set_network_testnet()?;
 
 // For Mainnet
-set_network_id(NetworkId::MAINNET)?;
+set_network_mainnet()?;
 ```
 
 The network ID affects the domain separation in signatures, so signatures generated for one network will not verify on another.

--- a/frost-bluepallas/src/hasher.rs
+++ b/frost-bluepallas/src/hasher.rs
@@ -23,6 +23,16 @@ pub fn set_network_id(network_id: NetworkId) -> Result<(), BluePallasError> {
     Ok(())
 }
 
+/// Convenience function to set the network to TESTNET
+pub fn set_network_testnet() -> Result<(), BluePallasError> {
+    set_network_id(NetworkId::TESTNET)
+}
+
+/// Convenience function to set the network to MAINNET
+pub fn set_network_mainnet() -> Result<(), BluePallasError> {
+    set_network_id(NetworkId::MAINNET)
+}
+
 /// Get the network ID for the current thread, returns error if not set
 pub fn get_network_id() -> Result<NetworkId, BluePallasError> {
     NETWORK_ID.with(|id| id.borrow().clone().ok_or(BluePallasError::NetworkIdNotSet))

--- a/frost-client/README.md
+++ b/frost-client/README.md
@@ -4,6 +4,12 @@ Forked from https://github.com/ZcashFoundation/frost-zcash-demo/tree/main/frost-
 # Zcash Foundation original documentation
 https://frost.zfnd.org/zcash/ywallet-demo.html
 
+## Network selection
+
+The `coordinator` subcommand accepts a `--network` flag to choose between
+`testnet` (default) and `mainnet`. The chosen network is sent to participants
+for confirmation before signing.
+
 # Trusted Dealer
 
 ## Example

--- a/frost-client/src/api.rs
+++ b/frost-client/src/api.rs
@@ -117,6 +117,8 @@ pub struct CloseSessionArgs {
 #[serde(bound = "C: Ciphersuite")]
 pub struct SendSigningPackageArgs<C: Ciphersuite> {
     pub signing_package: Vec<SigningPackage<C>>,
+    /// Network id as integer: 0 for TESTNET, 1 for MAINNET.
+    pub network_id: u8,
     #[serde(
         serialize_with = "serdect::slice::serialize_hex_lower_or_bin",
         deserialize_with = "serdect::slice::deserialize_hex_or_bin_vec"

--- a/frost-client/src/cli/args.rs
+++ b/frost-client/src/cli/args.rs
@@ -1,3 +1,4 @@
+use crate::network::Network;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser, Clone)]
@@ -189,6 +190,9 @@ pub enum Command {
         /// human-readable hex-string is printed to stdout.
         #[arg(short = 'o', long, default_value = "")]
         signature: String,
+        /// Network to use (testnet or mainnet)
+        #[arg(long, value_enum, default_value_t = Network::Testnet)]
+        network: Network,
     },
     /// Participate in a FROST signing session.
     Participant {

--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 use super::args::Command;
+use crate::network::Network;
 use super::config::Config as ConfigFile;
 
 pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
@@ -33,6 +34,7 @@ pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
         signers,
         message,
         signature: signature_path,
+        network,
     } = (*args).clone()
     else {
         panic!("invalid Command");
@@ -56,6 +58,7 @@ pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
         message_paths: &message,
         output: &mut output,
         input: &mut input,
+        network,
     };
 
     let coordinator_config = setup_coordinator_config::<C>(public_key_package, signers, params)?;
@@ -149,6 +152,7 @@ struct CoordinatorSetupParams<'a> {
     message_paths: &'a [String],
     output: &'a mut dyn Write,
     input: &'a mut dyn BufRead,
+    network: Network,
 }
 
 /// Setup coordinator configuration for signing
@@ -209,6 +213,7 @@ fn setup_coordinator_config<C: Ciphersuite + 'static>(
                 .pubkey
                 .clone(),
         ),
+        network: params.network,
     };
 
     Ok(coordinator_config)

--- a/frost-client/src/coordinator/comms.rs
+++ b/frost-client/src/coordinator/comms.rs
@@ -31,6 +31,7 @@ pub enum Message<C: Ciphersuite> {
     },
     SigningPackage {
         signing_package: SigningPackage<C>,
+        network_id: u8,
     },
     SignatureShare(SignatureShare<C>),
 }

--- a/frost-client/src/coordinator/comms/http.rs
+++ b/frost-client/src/coordinator/comms/http.rs
@@ -160,6 +160,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
             .expect("cipher must have been set before");
         let send_signing_package_config = SendSigningPackageArgs {
             signing_package: vec![signing_package.clone()],
+            network_id: self.config.network.into(),
             aux_msg: Default::default(),
         };
 

--- a/frost-client/src/coordinator/comms/socket.rs
+++ b/frost-client/src/coordinator/comms/socket.rs
@@ -6,6 +6,7 @@ use frost_core as frost;
 
 use frost_core::Ciphersuite;
 
+use crate::network::Network;
 use eyre::eyre;
 use message_io::{
     network::{Endpoint, NetEvent, Transport},
@@ -32,6 +33,7 @@ pub struct SocketComms<C: Ciphersuite> {
     input_rx: Receiver<(Endpoint, Vec<u8>)>,
     endpoints: BTreeMap<Identifier<C>, Endpoint>,
     handler: NodeHandler<()>,
+    network: Network,
     _phantom: PhantomData<C>,
 }
 
@@ -50,6 +52,7 @@ impl<C: Ciphersuite> SocketComms<C> {
             input_rx: rx,
             endpoints: BTreeMap::new(),
             handler,
+            network: config.network,
             _phantom: Default::default(),
         };
 
@@ -117,6 +120,7 @@ impl<C: Ciphersuite> Comms<C> for SocketComms<C> {
 
         let data = serde_json::to_vec(&Message::SigningPackage {
             signing_package: signing_package.clone(),
+            network_id: self.network.into(),
         })?;
 
         for identifier in signing_package.signing_commitments().keys() {

--- a/frost-client/src/coordinator/config.rs
+++ b/frost-client/src/coordinator/config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::cipher::{PrivateKey, PublicKey};
+use crate::network::Network;
 use frost_core::{keys::PublicKeyPackage, Ciphersuite, Identifier};
 
 #[derive(Clone)]
@@ -33,4 +34,7 @@ pub struct Config<C: Ciphersuite> {
 
     /// The coordinator's communication public key for HTTP mode.
     pub comm_pubkey: Option<PublicKey>,
+
+    /// Network to use for signing.
+    pub network: Network,
 }

--- a/frost-client/src/coordinator/sign.rs
+++ b/frost-client/src/coordinator/sign.rs
@@ -10,6 +10,7 @@ use super::comms::http::HTTPComms;
 use super::comms::socket::SocketComms;
 use super::comms::Comms;
 use super::config::Config;
+use frost_bluepallas::hasher::{set_network_mainnet, set_network_testnet};
 
 #[derive(Debug, PartialEq)]
 pub struct ParticipantsConfig<C: Ciphersuite> {
@@ -22,6 +23,10 @@ pub async fn sign<C: Ciphersuite + 'static>(
     reader: &mut impl BufRead,
     logger: &mut impl Write,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    match config.network {
+        crate::network::Network::Testnet => set_network_testnet()?,
+        crate::network::Network::Mainnet => set_network_mainnet()?,
+    }
     let mut comms: Box<dyn Comms<C>> = if config.socket {
         Box::new(SocketComms::new(config))
     } else {

--- a/frost-client/src/lib.rs
+++ b/frost-client/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod client;
 pub mod coordinator;
 pub mod dkg;
+pub mod network;
 pub mod participant;
 pub mod session;
 pub mod trusted_dealer;

--- a/frost-client/src/network.rs
+++ b/frost-client/src/network.rs
@@ -1,0 +1,29 @@
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+/// Network to use for signing operations.
+#[derive(Copy, Clone, Debug, ValueEnum, Serialize, Deserialize)]
+pub enum Network {
+    Testnet,
+    Mainnet,
+}
+
+impl From<Network> for u8 {
+    fn from(n: Network) -> Self {
+        match n {
+            Network::Testnet => 0,
+            Network::Mainnet => 1,
+        }
+    }
+}
+
+impl TryFrom<u8> for Network {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Network::Testnet),
+            1 => Ok(Network::Mainnet),
+            _ => Err(()),
+        }
+    }
+}

--- a/frost-client/src/participant/comms.rs
+++ b/frost-client/src/participant/comms.rs
@@ -30,6 +30,7 @@ pub enum Message<C: Ciphersuite> {
     },
     SigningPackage {
         signing_package: frost::SigningPackage<C>,
+        network_id: u8,
     },
     SignatureShare(SignatureShare<C>),
 }
@@ -61,7 +62,12 @@ pub trait Comms<C: Ciphersuite> {
     ) -> Result<(), Box<dyn Error>> {
         writeln!(
             output,
-            "Message to be signed (hex-encoded):\n{}\nDo you want to sign it? (y/n)",
+            "Network: {}\nMessage to be signed (hex-encoded):\n{}\nDo you want to sign it? (y/n)",
+            match signing_package.network_id {
+                0 => "TESTNET",
+                1 => "MAINNET",
+                _ => "UNKNOWN",
+            },
             hex::encode(signing_package.signing_package[0].message())
         )?;
         let mut sign_it = String::new();

--- a/frost-client/src/participant/comms/socket.rs
+++ b/frost-client/src/participant/comms/socket.rs
@@ -105,9 +105,14 @@ where
             .ok_or(eyre!("Did not receive signing package!"))?;
 
         let message: Message<C> = serde_json::from_slice(&data)?;
-        if let Message::SigningPackage { signing_package } = message {
+        if let Message::SigningPackage {
+            signing_package,
+            network_id,
+        } = message
+        {
             Ok(SendSigningPackageArgs::<C> {
                 signing_package: vec![signing_package],
+                network_id,
                 aux_msg: vec![],
             })
         } else {

--- a/frost-client/src/participant/sign.rs
+++ b/frost-client/src/participant/sign.rs
@@ -5,6 +5,8 @@ use super::comms::socket::SocketComms;
 
 use super::comms::Comms;
 
+use crate::network::Network;
+use frost_bluepallas::hasher::{set_network_mainnet, set_network_testnet};
 use frost_core::Ciphersuite;
 use rand::thread_rng;
 use std::io::{BufRead, Write};
@@ -42,6 +44,11 @@ pub async fn sign<C: Ciphersuite + 'static>(
     comms
         .confirm_message(input, logger, &round_2_config)
         .await?;
+
+    match Network::try_from(round_2_config.network_id).unwrap_or(Network::Testnet) {
+        Network::Testnet => set_network_testnet()?,
+        Network::Mainnet => set_network_mainnet()?,
+    }
 
     let signing_package = round_2_config.signing_package.first().unwrap();
 


### PR DESCRIPTION
## Summary
- remove direct mina-signer dependency from client
- introduce `Network` enum and new `set_network_testnet`/`set_network_mainnet` helpers
- update coordinator/participant code to use new enum
- document network helpers in bluepallas README

## Testing
- `cargo clippy --all-targets --all-features -- -D clippy::all -W clippy::too_many_arguments`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688c93054850832da8b02bfaae7fe074