### PR TITLE
fix: require explicit threshold for keygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cargo run --bin frost-client -- init -c eve.toml
 cargo run --bin frost-client -- trusted-dealer \
   -d "Alice, Bob and Eve's group" \
   --names Alice,Bob,Eve \
+  -t 2 -n 3 \
   -c alice.toml -c bob.toml -c eve.toml \
   -C bluepallas
 ```

--- a/frost-client/examples/trusted_dealer_example/trusted_dealer_example.sh
+++ b/frost-client/examples/trusted_dealer_example/trusted_dealer_example.sh
@@ -24,8 +24,9 @@ echo "Generating FROST key shares using trusted dealer..."
 cargo run --bin frost-client -- trusted-dealer \
     -d "Alice, Bob and Eve's group" \
     --names Alice,Bob,Eve \
+    -t 2 -n 3 \
     -c "$GENERATED_DIR/alice.toml" \
     -c "$GENERATED_DIR/bob.toml" \
     -c "$GENERATED_DIR/eve.toml"
 
-echo "Key generation complete. Check the generated directory for the config files." 
+echo "Key generation complete. Check the generated directory for the config files."

--- a/frost-client/src/cli/args.rs
+++ b/frost-client/src/cli/args.rs
@@ -96,7 +96,7 @@ pub enum Command {
         #[arg(short, long)]
         server_url: Option<String>,
         /// The threshold (minimum number of signers).
-        #[arg(short = 't', long, default_value_t = 2)]
+        #[arg(short = 't', long)]
         threshold: u16,
         /// The total number of participants (maximum number of signers).
         #[arg(short = 'n', long, default_value_t = 3)]

--- a/frost-client/src/cli/args.rs
+++ b/frost-client/src/cli/args.rs
@@ -99,7 +99,7 @@ pub enum Command {
         #[arg(short = 't', long)]
         threshold: u16,
         /// The total number of participants (maximum number of signers).
-        #[arg(short = 'n', long, default_value_t = 3)]
+        #[arg(short = 'n', long)]
         num_signers: u16,
     },
     /// Generate FROST shares using Distributed Key Generation.


### PR DESCRIPTION
## Summary
- remove default threshold from trusted-dealer key generation
- document explicit threshold usage in README and example script

## Testing
- `cargo clippy --all-targets --all-features -- -D clippy::all -W clippy::too_many_arguments`
- `cargo test`
- `pre-commit run --files README.md frost-client/examples/trusted_dealer_example/trusted_dealer_example.sh frost-client/src/cli/args.rs`


------
https://chatgpt.com/codex/tasks/task_e_68908438d340832dabc49b2d3ddd0a71