### PR TITLE
Make the relevant types generic structs over the ciphersuite in Frost Client

### DIFF
--- a/frost-client/src/cli/ciphersuite_helper.rs
+++ b/frost-client/src/cli/ciphersuite_helper.rs
@@ -1,6 +1,5 @@
 use std::{error::Error, marker::PhantomData};
 
-use eyre::eyre;
 use frost_core::{
     keys::{KeyPackage, PublicKeyPackage},
     Ciphersuite,
@@ -18,7 +17,7 @@ pub struct GroupInfo {
 }
 
 /// A trait that helps obtaining ciphersuite-dependent information.
-pub trait CiphersuiteHelper {
+pub trait CiphersuiteHelper<C: Ciphersuite> {
     fn group_info(
         &self,
         encoded_key_package: &[u8],
@@ -43,16 +42,11 @@ where
 }
 
 /// Get a CiphersuiteHelper for the given ciphersuite.
-pub(crate) fn ciphersuite_helper(
-    ciphersuite_id: &str,
-) -> Result<Box<dyn CiphersuiteHelper>, Box<dyn Error>> {
-    if ciphersuite_id == PallasPoseidon::ID {
-        return Ok(Box::new(CiphersuiteHelperImpl::<PallasPoseidon>::default()));
-    }
-    Err(eyre!("invalid ciphersuite ID").into())
+pub(crate) fn ciphersuite_helper<C: Ciphersuite>() -> Box<dyn CiphersuiteHelper<C>> {
+    Box::new(CiphersuiteHelperImpl::<C>::default())
 }
 
-impl<C> CiphersuiteHelper for CiphersuiteHelperImpl<C>
+impl<C> CiphersuiteHelper<C> for CiphersuiteHelperImpl<C>
 where
     C: Ciphersuite + 'static,
 {

--- a/frost-client/src/cli/config.rs
+++ b/frost-client/src/cli/config.rs
@@ -10,6 +10,7 @@ use crate::cipher::{PrivateKey, PublicKey};
 use eyre::{eyre, OptionExt};
 use frost_core::{Ciphersuite, Identifier};
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use super::{ciphersuite_helper::ciphersuite_helper, contact::Contact, write_atomic};
@@ -87,11 +88,10 @@ pub struct CommunicationKey {
     pub pubkey: PublicKey,
 }
 
-use std::marker::PhantomData;
-
 /// A FROST group the user belongs to.
 #[derive(Clone, Debug, Serialize, Deserialize, Zeroize)]
 pub struct Group<C: Ciphersuite> {
+    #[serde(skip)]
     pub _phantom: PhantomData<C>,
     /// A human-readable description of the group to make it easier to select
     /// groups

--- a/frost-client/src/cli/config.rs
+++ b/frost-client/src/cli/config.rs
@@ -15,8 +15,12 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 use super::{ciphersuite_helper::ciphersuite_helper, contact::Contact, write_atomic};
 
 /// The config file, which is serialized with serde.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct Config {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "BTreeMap<String, Group<C>>: Serialize",
+    deserialize = "BTreeMap<String, Group<C>>: Deserialize<'de>"
+))]
+pub struct Config<C: Ciphersuite> {
     /// The path the config was loaded from.
     #[serde(skip)]
     path: Option<PathBuf>,
@@ -28,18 +32,35 @@ pub struct Config {
     pub contact: BTreeMap<String, Contact>,
     /// The FROST groups the user belongs to, keyed by hex-encoded verifying key
     #[serde(default)]
-    pub group: BTreeMap<String, Group>,
+    pub group: BTreeMap<String, Group<C>>,
 }
 
-impl Zeroize for Config {
+/// Manual derive to place a bound on BTreeMap<...> since otherwise the compiler
+/// will demand that C: Default
+impl<C: Ciphersuite> Default for Config<C>
+where
+    BTreeMap<String, Group<C>>: Default,
+{
+    fn default() -> Self {
+        Self {
+            path: None,
+            version: 0,
+            communication_key: None,
+            contact: BTreeMap::new(),
+            group: BTreeMap::new(),
+        }
+    }
+}
+
+impl<C: Ciphersuite> Zeroize for Config<C> {
     fn zeroize(&mut self) {
         self.group.iter_mut().for_each(|(_, g)| g.zeroize());
     }
 }
 
-impl ZeroizeOnDrop for Config {}
+impl<C: Ciphersuite> ZeroizeOnDrop for Config<C> {}
 
-impl Config {
+impl<C: Ciphersuite> Config<C> {
     pub fn contact_by_pubkey(&self, pubkey: &PublicKey) -> Result<Contact, Box<dyn Error>> {
         if Some(pubkey) == self.communication_key.as_ref().map(|c| &c.pubkey) {
             return Ok(Contact {
@@ -66,14 +87,15 @@ pub struct CommunicationKey {
     pub pubkey: PublicKey,
 }
 
+use std::marker::PhantomData;
+
 /// A FROST group the user belongs to.
 #[derive(Clone, Debug, Serialize, Deserialize, Zeroize)]
-pub struct Group {
+pub struct Group<C: Ciphersuite> {
+    pub _phantom: PhantomData<C>,
     /// A human-readable description of the group to make it easier to select
     /// groups
     pub description: String,
-    /// The ciphersuite being used for the group
-    pub ciphersuite: String,
     /// The encoded public key package for the group.
     #[serde(
         serialize_with = "serdect::slice::serialize_hex_lower_or_bin",
@@ -93,13 +115,13 @@ pub struct Group {
     pub participant: BTreeMap<String, Participant>,
 }
 
-impl ZeroizeOnDrop for Group {}
+impl<C: Ciphersuite> ZeroizeOnDrop for Group<C> {}
 
-impl Group {
+impl<C: Ciphersuite> Group<C> {
     /// Returns a human-readable summary of the contact; used when it is
     /// printed to the terminal.
-    pub fn as_human_readable_summary(&self, config: &Config) -> Result<String, Box<dyn Error>> {
-        let helper = ciphersuite_helper(&self.ciphersuite)?;
+    pub fn as_human_readable_summary(&self, config: &Config<C>) -> Result<String, Box<dyn Error>> {
+        let helper = ciphersuite_helper::<C>();
         let info = helper.group_info(&self.key_package, &self.public_key_package)?;
         let mut s = format!(
             "Group \"{}\"\nPublic key (hex format): {}\nPublic key (mina format): {}\nServer URL: {}\nThreshold: {}\nParticipants: {}\n",
@@ -148,7 +170,7 @@ impl Participant {
     }
 }
 
-impl Config {
+impl<C: Ciphersuite> Config<C> {
     /// Returns the default path of the config
     /// ($HOME/.config/frost/credentials.toml in Linux) if `path` is None,
     /// otherwise parse the given path and return it.
@@ -180,7 +202,7 @@ impl Config {
         }
         let bytes = Zeroizing::new(std::fs::read(&path)?);
         let s = str::from_utf8(&bytes)?;
-        let mut config: Config = toml::from_str(s)?;
+        let mut config: Config<C> = toml::from_str(s)?;
         config.path = Some(path);
         Ok(config)
     }

--- a/frost-client/src/cli/contact.rs
+++ b/frost-client/src/cli/contact.rs
@@ -5,7 +5,7 @@ const CONTACT_HRP: &str = "minafrost";
 
 use crate::cipher::PublicKey;
 use eyre::{eyre, OptionExt};
-use frost_bluepallas::PallasPoseidon;
+use frost_core::Ciphersuite;
 use serde::{Deserialize, Serialize};
 
 use super::{args::Command, config::Config};
@@ -56,7 +56,7 @@ impl Contact {
 }
 
 /// Import a contact into the user's address book, in the config file.
-pub fn import(args: &Command) -> Result<(), Box<dyn Error>> {
+pub fn import<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Import {
         contact: text_contact,
         config,
@@ -65,7 +65,7 @@ pub fn import(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let mut config = Config::<PallasPoseidon>::read(config)?;
+    let mut config = Config::<C>::read(config)?;
 
     let mut contact = Contact::from_text(&text_contact)?;
     if config.contact.contains_key(&contact.name) {
@@ -104,12 +104,12 @@ pub fn import(args: &Command) -> Result<(), Box<dyn Error>> {
 }
 
 /// Export a contact from the user's address book in the config file.
-pub fn export(args: &Command) -> Result<(), Box<dyn Error>> {
+pub fn export<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Export { name, config } = (*args).clone() else {
         panic!("invalid Command");
     };
 
-    let config = Config::<PallasPoseidon>::read(config)?;
+    let config = Config::<C>::read(config)?;
 
     // Build the contact to export.
     let contact = Contact {
@@ -134,12 +134,12 @@ pub fn export(args: &Command) -> Result<(), Box<dyn Error>> {
 }
 
 /// List the contacts in the address book in the config file.
-pub fn list(args: &Command) -> Result<(), Box<dyn Error>> {
+pub fn list<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Contacts { config } = (*args).clone() else {
         panic!("invalid Command");
     };
 
-    let config = Config::<PallasPoseidon>::read(config)?;
+    let config = Config::<C>::read(config)?;
 
     for contact in config.contact.values() {
         eprint!("{}", contact.as_human_readable_summary());
@@ -151,12 +151,12 @@ pub fn list(args: &Command) -> Result<(), Box<dyn Error>> {
 }
 
 /// Remove a contact from the user's address book in the config file.
-pub fn remove(args: &Command) -> Result<(), Box<dyn Error>> {
+pub fn remove<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::RemoveContact { config, pubkey } = (*args).clone() else {
         panic!("invalid Command");
     };
 
-    let mut config = Config::<PallasPoseidon>::read(config)?;
+    let mut config = Config::<C>::read(config)?;
 
     let name = config
         .contact

--- a/frost-client/src/cli/contact.rs
+++ b/frost-client/src/cli/contact.rs
@@ -5,6 +5,7 @@ const CONTACT_HRP: &str = "minafrost";
 
 use crate::cipher::PublicKey;
 use eyre::{eyre, OptionExt};
+use frost_bluepallas::PallasPoseidon;
 use serde::{Deserialize, Serialize};
 
 use super::{args::Command, config::Config};
@@ -64,7 +65,7 @@ pub fn import(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let mut config = Config::read(config)?;
+    let mut config = Config::<PallasPoseidon>::read(config)?;
 
     let mut contact = Contact::from_text(&text_contact)?;
     if config.contact.contains_key(&contact.name) {
@@ -108,7 +109,7 @@ pub fn export(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let config = Config::read(config)?;
+    let config = Config::<PallasPoseidon>::read(config)?;
 
     // Build the contact to export.
     let contact = Contact {
@@ -138,7 +139,7 @@ pub fn list(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let config = Config::read(config)?;
+    let config = Config::<PallasPoseidon>::read(config)?;
 
     for contact in config.contact.values() {
         eprint!("{}", contact.as_human_readable_summary());
@@ -155,7 +156,7 @@ pub fn remove(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let mut config = Config::read(config)?;
+    let mut config = Config::<PallasPoseidon>::read(config)?;
 
     let name = config
         .contact

--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -109,7 +109,14 @@ pub fn read_messages(
 fn load_coordinator_config<C: Ciphersuite>(
     config_path: Option<String>,
     group_id: &str,
-) -> Result<(ConfigFile, crate::cli::config::Group, PublicKeyPackage<C>), Box<dyn Error>> {
+) -> Result<
+    (
+        ConfigFile<C>,
+        crate::cli::config::Group<C>,
+        PublicKeyPackage<C>,
+    ),
+    Box<dyn Error>,
+> {
     let user_config = ConfigFile::read(config_path)?;
 
     let group_config = user_config
@@ -130,7 +137,7 @@ fn load_coordinator_config<C: Ciphersuite>(
 /// and maps them to their corresponding identifiers from the group config.
 fn parse_signers<C: Ciphersuite>(
     signer_args: &[String],
-    group_config: &crate::cli::config::Group,
+    group_config: &crate::cli::config::Group<C>,
 ) -> Result<HashMap<PublicKey, frost_core::Identifier<C>>, Box<dyn Error>> {
     signer_args
         .iter()
@@ -146,9 +153,9 @@ fn parse_signers<C: Ciphersuite>(
 ///
 /// This structure groups related parameters to avoid the Clippy warning about
 /// functions with too many arguments.
-struct CoordinatorSetupParams<'a> {
-    user_config: &'a ConfigFile,
-    group_config: &'a crate::cli::config::Group,
+struct CoordinatorSetupParams<'a, C: Ciphersuite> {
+    user_config: &'a ConfigFile<C>,
+    group_config: &'a crate::cli::config::Group<C>,
     server_url: Option<String>,
     message_paths: &'a [String],
     output: &'a mut dyn Write,
@@ -163,7 +170,7 @@ struct CoordinatorSetupParams<'a> {
 fn setup_coordinator_config<C: Ciphersuite + 'static>(
     public_key_package: PublicKeyPackage<C>,
     signers: HashMap<PublicKey, frost_core::Identifier<C>>,
-    params: CoordinatorSetupParams,
+    params: CoordinatorSetupParams<C>,
 ) -> Result<CoordinatorConfig<C>, Box<dyn Error>> {
     // Determine server URL
     let server_url = if let Some(server_url) = params.server_url {

--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use eyre::Context;
 use eyre::OptionExt;
-use frost_bluepallas::{transactions::Transaction, translate::Translatable, PallasPoseidon};
+use frost_bluepallas::{transactions::Transaction, translate::Translatable};
 use frost_core::keys::PublicKeyPackage;
 use frost_core::Ciphersuite;
 use reqwest::Url;
@@ -21,13 +21,7 @@ use super::args::Command;
 use super::config::Config as ConfigFile;
 use crate::mina_network::Network;
 
-pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
-    run_for_ciphersuite::<PallasPoseidon>(args).await
-}
-
-pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
-    args: &Command,
-) -> Result<(), Box<dyn Error>> {
+pub async fn run<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Coordinator {
         config: config_path,
         server_url,
@@ -167,7 +161,7 @@ struct CoordinatorSetupParams<'a, C: Ciphersuite> {
 ///
 /// This function constructs the CoordinatorConfig with all necessary parameters
 /// including network settings, keys, signers, and messages.
-fn setup_coordinator_config<C: Ciphersuite + 'static>(
+fn setup_coordinator_config<C: Ciphersuite>(
     public_key_package: PublicKeyPackage<C>,
     signers: HashMap<PublicKey, frost_core::Identifier<C>>,
     params: CoordinatorSetupParams<C>,

--- a/frost-client/src/cli/dkg.rs
+++ b/frost-client/src/cli/dkg.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, HashMap},
     error::Error,
+    marker::PhantomData,
     rc::Rc,
 };
 
 use eyre::{Context as _, OptionExt};
 
-use frost_bluepallas::PallasPoseidon;
 use frost_core::Ciphersuite;
 use reqwest::Url;
 use zeroize::Zeroizing;
@@ -23,14 +23,7 @@ use crate::dkg;
 ///
 /// Generates FROST key shares using distributed key generation protocol
 /// and updates the participant config file with group information.
-pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
-    run_for_ciphersuite::<frost_bluepallas::PallasPoseidon>(args).await
-}
-
-/// Distributed key generation for a specific ciphersuite
-pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
-    args: &Command,
-) -> Result<(), Box<dyn Error>> {
+pub async fn run<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Dkg {
         config: config_path,
         description,
@@ -46,7 +39,8 @@ pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
     let mut output = std::io::stdout();
 
     // Setup DKG configuration
-    let dkg_config = setup_dkg_config(config_path.clone(), &server_url, threshold, &participants)?;
+    let dkg_config =
+        setup_dkg_config::<C>(config_path.clone(), &server_url, threshold, &participants)?;
 
     // Generate key shares through DKG
     let (key_package, public_key_package, pubkey_map) =
@@ -73,13 +67,13 @@ pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
 ///
 /// This function reads the participant's config file, parses the server URL,
 /// and constructs the DKG configuration needed for key generation.
-fn setup_dkg_config(
+fn setup_dkg_config<C: Ciphersuite>(
     config_path: Option<String>,
     server_url: &str,
     threshold: u16,
     participants: &[String],
 ) -> Result<dkg::Config, Box<dyn Error>> {
-    let config = Config::<PallasPoseidon>::read(config_path)?;
+    let config = Config::<C>::read(config_path)?;
 
     let server_url_parsed =
         Url::parse(&format!("https://{}", server_url)).wrap_err("error parsing server-url")?;
@@ -164,7 +158,7 @@ fn create_participants_map<C: Ciphersuite>(
 ///
 /// This function takes the generated key package and updates the participant's config
 /// file with the group information.
-fn update_config_with_group<C: Ciphersuite + 'static>(
+fn update_config_with_group<C: Ciphersuite>(
     config_path: Option<String>,
     description: &str,
     server_url: &str,
@@ -173,7 +167,7 @@ fn update_config_with_group<C: Ciphersuite + 'static>(
     participants: &BTreeMap<String, Participant>,
 ) -> Result<(), Box<dyn Error>> {
     let group = Group::<C> {
-        _phantom: Default::default(),
+        _phantom: PhantomData,
         description: description.to_string(),
         key_package: postcard::to_allocvec(key_package)?,
         public_key_package: postcard::to_allocvec(public_key_package)?,

--- a/frost-client/src/cli/dkg.rs
+++ b/frost-client/src/cli/dkg.rs
@@ -6,6 +6,7 @@ use std::{
 
 use eyre::{Context as _, OptionExt};
 
+use frost_bluepallas::PallasPoseidon;
 use frost_core::Ciphersuite;
 use reqwest::Url;
 use zeroize::Zeroizing;
@@ -78,7 +79,7 @@ fn setup_dkg_config(
     threshold: u16,
     participants: &[String],
 ) -> Result<dkg::Config, Box<dyn Error>> {
-    let config = Config::read(config_path)?;
+    let config = Config::<PallasPoseidon>::read(config_path)?;
 
     let server_url_parsed =
         Url::parse(&format!("https://{}", server_url)).wrap_err("error parsing server-url")?;
@@ -171,8 +172,8 @@ fn update_config_with_group<C: Ciphersuite + 'static>(
     public_key_package: &frost_core::keys::PublicKeyPackage<C>,
     participants: &BTreeMap<String, Participant>,
 ) -> Result<(), Box<dyn Error>> {
-    let group = Group {
-        ciphersuite: C::ID.to_string(),
+    let group = Group::<C> {
+        _phantom: Default::default(),
         description: description.to_string(),
         key_package: postcard::to_allocvec(key_package)?,
         public_key_package: postcard::to_allocvec(public_key_package)?,

--- a/frost-client/src/cli/group.rs
+++ b/frost-client/src/cli/group.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use eyre::OptionExt;
+use frost_bluepallas::PallasPoseidon;
 
 use super::{args::Command, config::Config};
 
@@ -9,7 +10,7 @@ pub fn list(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let config = Config::read(config)?;
+    let config = Config::<PallasPoseidon>::read(config)?;
 
     for group in config.group.values() {
         eprint!("{}", group.as_human_readable_summary(&config)?);
@@ -25,7 +26,7 @@ pub fn remove(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let mut config = Config::read(config)?;
+    let mut config = Config::<PallasPoseidon>::read(config)?;
 
     config.group.remove(&group).ok_or_eyre("group not found")?;
 

--- a/frost-client/src/cli/group.rs
+++ b/frost-client/src/cli/group.rs
@@ -1,16 +1,16 @@
 use std::error::Error;
 
 use eyre::OptionExt;
-use frost_bluepallas::PallasPoseidon;
+use frost_core::Ciphersuite;
 
 use super::{args::Command, config::Config};
 
-pub fn list(args: &Command) -> Result<(), Box<dyn Error>> {
+pub fn list<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Groups { config } = (*args).clone() else {
         panic!("invalid Command");
     };
 
-    let config = Config::<PallasPoseidon>::read(config)?;
+    let config = Config::<C>::read(config)?;
 
     for group in config.group.values() {
         eprint!("{}", group.as_human_readable_summary(&config)?);
@@ -21,12 +21,12 @@ pub fn list(args: &Command) -> Result<(), Box<dyn Error>> {
 }
 
 /// Remove a group from the user's config file.
-pub fn remove(args: &Command) -> Result<(), Box<dyn Error>> {
+pub fn remove<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::RemoveGroup { config, group } = (*args).clone() else {
         panic!("invalid Command");
     };
 
-    let mut config = Config::<PallasPoseidon>::read(config)?;
+    let mut config = Config::<C>::read(config)?;
 
     config.group.remove(&group).ok_or_eyre("group not found")?;
 

--- a/frost-client/src/cli/init.rs
+++ b/frost-client/src/cli/init.rs
@@ -1,22 +1,21 @@
 use std::error::Error;
 
-use frost_bluepallas::PallasPoseidon;
-
 use crate::cipher::Cipher;
+use frost_core::Ciphersuite;
 
 use super::{
     args::Command,
     config::{CommunicationKey, Config},
 };
 
-pub async fn init(args: &Command) -> Result<(), Box<dyn Error>> {
+pub async fn init<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Init { config } = (*args).clone() else {
         panic!("invalid Command");
     };
 
     // To make frost client truly ciphersuite agnostic provide the ciphersuite as user flag
     // We don't do this cause it would just be more boilerplate at the moment
-    let mut config = Config::<PallasPoseidon>::read(config)?;
+    let mut config = Config::<C>::read(config)?;
 
     if config.communication_key.is_some() {
         eprintln!("Skipping keypair generation; keypair already generated and stored");

--- a/frost-client/src/cli/init.rs
+++ b/frost-client/src/cli/init.rs
@@ -1,5 +1,7 @@
 use std::error::Error;
 
+use frost_bluepallas::PallasPoseidon;
+
 use crate::cipher::Cipher;
 
 use super::{
@@ -12,7 +14,9 @@ pub async fn init(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let mut config = Config::read(config)?;
+    // To make frost client truly ciphersuite agnostic provide the ciphersuite as user flag
+    // We don't do this cause it would just be more boilerplate at the moment
+    let mut config = Config::<PallasPoseidon>::read(config)?;
 
     if config.communication_key.is_some() {
         eprintln!("Skipping keypair generation; keypair already generated and stored");

--- a/frost-client/src/cli/participant.rs
+++ b/frost-client/src/cli/participant.rs
@@ -64,7 +64,7 @@ pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
 fn load_participant_config<C: Ciphersuite>(
     config_path: Option<String>,
     group_id: &str,
-) -> Result<(ConfigFile, crate::cli::config::Group, KeyPackage<C>), Box<dyn Error>> {
+) -> Result<(ConfigFile<C>, crate::cli::config::Group<C>, KeyPackage<C>), Box<dyn Error>> {
     let user_config = ConfigFile::read(config_path)?;
 
     let group_config = user_config
@@ -83,8 +83,8 @@ fn load_participant_config<C: Ciphersuite>(
 /// This function constructs the ParticipantConfig with all necessary parameters
 /// including network settings, keys, and coordinator lookup functionality.
 fn setup_participant_config<C: Ciphersuite + 'static>(
-    user_config: &ConfigFile,
-    group_config: &crate::cli::config::Group,
+    user_config: &ConfigFile<C>,
+    group_config: &crate::cli::config::Group<C>,
     key_package: KeyPackage<C>,
     server_url: Option<String>,
     session: Option<String>,

--- a/frost-client/src/cli/participant.rs
+++ b/frost-client/src/cli/participant.rs
@@ -5,26 +5,17 @@ use eyre::Context;
 use eyre::OptionExt;
 use reqwest::Url;
 
-use frost_bluepallas::PallasPoseidon;
 use frost_core::keys::KeyPackage;
 use frost_core::Ciphersuite;
 
 use super::{args::Command, config::Config as ConfigFile};
 
+use crate::cli::config::{Group, Participant};
 use crate::participant::sign;
 use crate::participant::Config as ParticipantConfig;
 
 /// CLI entry point for participant signing
-///
-/// Participates in a FROST signing session using PallasPoseidon ciphersuite.
-pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
-    run_for_ciphersuite::<PallasPoseidon>(args).await
-}
-
-/// Participant signing for a specific ciphersuite
-pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
-    args: &Command,
-) -> Result<(), Box<dyn Error>> {
+pub async fn run<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Participant {
         config: config_path,
         server_url,
@@ -64,7 +55,7 @@ pub(crate) async fn run_for_ciphersuite<C: Ciphersuite + 'static>(
 fn load_participant_config<C: Ciphersuite>(
     config_path: Option<String>,
     group_id: &str,
-) -> Result<(ConfigFile<C>, crate::cli::config::Group<C>, KeyPackage<C>), Box<dyn Error>> {
+) -> Result<(ConfigFile<C>, Group<C>, KeyPackage<C>), Box<dyn Error>> {
     let user_config = ConfigFile::read(config_path)?;
 
     let group_config = user_config
@@ -82,9 +73,9 @@ fn load_participant_config<C: Ciphersuite>(
 ///
 /// This function constructs the ParticipantConfig with all necessary parameters
 /// including network settings, keys, and coordinator lookup functionality.
-fn setup_participant_config<C: Ciphersuite + 'static>(
+fn setup_participant_config<C: Ciphersuite>(
     user_config: &ConfigFile<C>,
-    group_config: &crate::cli::config::Group<C>,
+    group_config: &Group<C>,
     key_package: KeyPackage<C>,
     server_url: Option<String>,
     session: Option<String>,
@@ -148,7 +139,7 @@ type CoordinatorPubkeyGetter = Rc<dyn Fn(&crate::api::PublicKey) -> Option<crate
 /// This function creates a closure that can look up coordinator public keys
 /// from the group participants.
 fn create_coordinator_pubkey_getter(
-    group_participants: std::collections::BTreeMap<String, crate::cli::config::Participant>,
+    group_participants: std::collections::BTreeMap<String, Participant>,
 ) -> CoordinatorPubkeyGetter {
     Rc::new(move |coordinator_pubkey| {
         group_participants

--- a/frost-client/src/cli/session.rs
+++ b/frost-client/src/cli/session.rs
@@ -1,14 +1,14 @@
 use std::error::Error;
 
 use eyre::{eyre, OptionExt as _};
-use frost_bluepallas::PallasPoseidon;
+use frost_core::Ciphersuite;
 use rand::thread_rng;
 
 use crate::{api, client::Client};
 
 use super::{args::Command, config::Config};
 
-pub async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
+pub async fn list<C: Ciphersuite>(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Sessions {
         config,
         group,
@@ -19,7 +19,7 @@ pub async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let config = Config::<PallasPoseidon>::read(config)?;
+    let config = Config::<C>::read(config)?;
 
     let server_url = if let Some(server_url) = server_url {
         server_url

--- a/frost-client/src/cli/session.rs
+++ b/frost-client/src/cli/session.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use eyre::{eyre, OptionExt as _};
+use frost_bluepallas::PallasPoseidon;
 use rand::thread_rng;
 
 use crate::{api, client::Client};
@@ -18,7 +19,7 @@ pub async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
         panic!("invalid Command");
     };
 
-    let config = Config::read(config)?;
+    let config = Config::<PallasPoseidon>::read(config)?;
 
     let server_url = if let Some(server_url) = server_url {
         server_url

--- a/frost-client/src/cli/trusted_dealer.rs
+++ b/frost-client/src/cli/trusted_dealer.rs
@@ -91,7 +91,7 @@ fn extract_participant_info<C: Ciphersuite>(
     let mut contacts = Vec::new();
 
     for (identifier, path, name) in izip!(shares.keys(), config_paths.iter(), names.iter()) {
-        let config = Config::read(Some(path.to_string()))?;
+        let config = Config::<PallasPoseidon>::read(Some(path.to_string()))?;
         let pubkey = config
             .communication_key
             .ok_or_eyre("config not initialized")?
@@ -135,8 +135,8 @@ fn update_config_files<C: Ciphersuite + 'static>(
         // [`SecretShare::commitment()`] is the same for all participants using
         // a broadcast channel.
         let key_package: KeyPackage<C> = share.clone().try_into()?;
-        let group = Group {
-            ciphersuite: C::ID.to_string(),
+        let group = Group::<C> {
+            _phantom: Default::default(),
             description: description.to_string(),
             key_package: postcard::to_allocvec(&key_package)?,
             public_key_package: postcard::to_allocvec(public_key_package)?,

--- a/frost-client/src/main.rs
+++ b/frost-client/src/main.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use clap::Parser;
+use frost_bluepallas::PallasPoseidon;
 use frost_client::cli;
 use frost_client::cli::args::{Args, Command};
 
@@ -10,18 +11,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
     match args.command {
-        Command::Init { .. } => cli::init::init(&args.command).await,
-        Command::Export { .. } => cli::contact::export(&args.command),
-        Command::Import { .. } => cli::contact::import(&args.command),
-        Command::Contacts { .. } => cli::contact::list(&args.command),
-        Command::RemoveContact { .. } => cli::contact::remove(&args.command),
-        Command::Groups { .. } => cli::group::list(&args.command),
-        Command::RemoveGroup { .. } => cli::group::remove(&args.command),
-        Command::Sessions { .. } => cli::session::list(&args.command).await,
-        Command::TrustedDealer { .. } => cli::trusted_dealer::run(&args.command),
-        Command::Dkg { .. } => cli::dkg::run(&args.command).await,
-        Command::Coordinator { .. } => cli::coordinator::run(&args.command).await,
-        Command::Participant { .. } => cli::participant::run(&args.command).await,
+        Command::Init { .. } => cli::init::init::<PallasPoseidon>(&args.command).await,
+        Command::Export { .. } => cli::contact::export::<PallasPoseidon>(&args.command),
+        Command::Import { .. } => cli::contact::import::<PallasPoseidon>(&args.command),
+        Command::Contacts { .. } => cli::contact::list::<PallasPoseidon>(&args.command),
+        Command::RemoveContact { .. } => cli::contact::remove::<PallasPoseidon>(&args.command),
+        Command::Groups { .. } => cli::group::list::<PallasPoseidon>(&args.command),
+        Command::RemoveGroup { .. } => cli::group::remove::<PallasPoseidon>(&args.command),
+        Command::Sessions { .. } => cli::session::list::<PallasPoseidon>(&args.command).await,
+        Command::TrustedDealer { .. } => cli::trusted_dealer::run::<PallasPoseidon>(&args.command),
+        Command::Dkg { .. } => cli::dkg::run::<PallasPoseidon>(&args.command).await,
+        Command::Coordinator { .. } => cli::coordinator::run::<PallasPoseidon>(&args.command).await,
+        Command::Participant { .. } => cli::participant::run::<PallasPoseidon>(&args.command).await,
     }?;
 
     Ok(())


### PR DESCRIPTION
Some of the data types in frost client are not generic over the ciphersuite though they should be. This has led to type erasure here in [dkg](https://github.com/Raspberry-Devs/mina-multi-sig/blob/main/frost-client/src/cli/dkg.rs#L175) for example and type casting here in [ciphersuite-helper](https://github.com/Raspberry-Devs/mina-multi-sig/blob/main/frost-client/src/cli/ciphersuite_helper.rs#L45-L52)

I want to remove this by maintaining the type information throughout.

This will also improve the incorrect abstraction of byte strings being used in various places in the client. As an example take the [`Group` Struct](https://github.com/Raspberry-Devs/mina-multi-sig/blob/main/frost-client/src/cli/config.rs#L82-L88)).
```
    pub public_key_package: Vec<u8>,
    pub key_package: Vec<u8>,
 ```
 
 It should ideally be:
 ```
    pub public_key_package: PublicKeyPackage<C>,
    pub key_package: PublicKeyPackage<C>,
 ```

