### PR TITLE
Frost client json tx output

### DIFF
--- a/frost-bluepallas/examples/mina-sign-tx.rs
+++ b/frost-bluepallas/examples/mina-sign-tx.rs
@@ -1,52 +1,12 @@
 use ark_ff::{BigInt, PrimeField};
-use frost_bluepallas::{transactions::Transaction, translate::Translatable, Error};
+use frost_bluepallas::{
+    signature::{PubKeySer, Sig, TransactionSignature},
+    transactions::Transaction,
+    translate::Translatable,
+    Error,
+};
 use frost_core::Ciphersuite;
 use mina_signer::{Keypair, PubKey, Signer};
-use serde::{
-    ser::{SerializeStruct, Serializer},
-    Serialize,
-};
-
-struct Sig {
-    field: BigInt<4>,
-    scalar: BigInt<4>,
-}
-
-impl Serialize for Sig {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("signature", 2)?;
-        state.serialize_field("field", &self.field.to_string())?;
-        state.serialize_field("scalar", &self.scalar.to_string())?;
-        state.end()
-    }
-}
-
-#[allow(non_snake_case)]
-struct PubKeySer {
-    pubKey: PubKey,
-}
-
-impl Serialize for PubKeySer {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("publicKey", 1)?;
-        state.serialize_field("address", &self.pubKey.into_address())?;
-        state.end()
-    }
-}
-
-#[allow(non_snake_case)]
-#[derive(Serialize)]
-struct TransactionSignature {
-    publicKey: PubKeySer,
-    signature: Sig,
-    payload: Transaction,
-}
 
 fn main() -> Result<(), Error> {
     // Private key in hex format

--- a/frost-bluepallas/src/errors.rs
+++ b/frost-bluepallas/src/errors.rs
@@ -28,6 +28,12 @@ pub enum BluePallasError {
 
     /// Invalid Public Key
     InvalidPublicKey(String),
+
+    /// No messages have been provided for signing
+    NoMessageProvided,
+
+    /// Saving Signature failed
+    SaveSignatureError(String),
 }
 
 impl fmt::Display for BluePallasError {
@@ -44,6 +50,12 @@ impl fmt::Display for BluePallasError {
             BluePallasError::InvalidCommitment(msg) => write!(f, "Invalid commitment: {}", msg),
             BluePallasError::InvalidSignature(msg) => write!(f, "Invalid signature: {}", msg),
             BluePallasError::InvalidPublicKey(msg) => write!(f, "Invalid public key: {}", msg),
+            BluePallasError::NoMessageProvided => {
+                write!(f, "No messages have been provided for signing")
+            }
+            BluePallasError::SaveSignatureError(msg) => {
+                write!(f, "Failed to save signature: {}", msg)
+            }
         }
     }
 }

--- a/frost-bluepallas/src/errors.rs
+++ b/frost-bluepallas/src/errors.rs
@@ -25,6 +25,9 @@ pub enum BluePallasError {
 
     /// Invalid Signature provided
     InvalidSignature(String),
+
+    /// Invalid Public Key
+    InvalidPublicKey(String),
 }
 
 impl fmt::Display for BluePallasError {
@@ -40,6 +43,7 @@ impl fmt::Display for BluePallasError {
             }
             BluePallasError::InvalidCommitment(msg) => write!(f, "Invalid commitment: {}", msg),
             BluePallasError::InvalidSignature(msg) => write!(f, "Invalid signature: {}", msg),
+            BluePallasError::InvalidPublicKey(msg) => write!(f, "Invalid public key: {}", msg),
         }
     }
 }

--- a/frost-bluepallas/src/errors.rs
+++ b/frost-bluepallas/src/errors.rs
@@ -22,6 +22,9 @@ pub enum BluePallasError {
 
     /// Invalid commitment provided
     InvalidCommitment(String),
+
+    /// Invalid Signature provided
+    InvalidSignature(String),
 }
 
 impl fmt::Display for BluePallasError {
@@ -36,6 +39,7 @@ impl fmt::Display for BluePallasError {
                 write!(f, "Deserialization error: {}", msg)
             }
             BluePallasError::InvalidCommitment(msg) => write!(f, "Invalid commitment: {}", msg),
+            BluePallasError::InvalidSignature(msg) => write!(f, "Invalid signature: {}", msg),
         }
     }
 }

--- a/frost-bluepallas/src/lib.rs
+++ b/frost-bluepallas/src/lib.rs
@@ -45,6 +45,7 @@ pub mod hasher;
 pub mod helper;
 pub mod keys;
 mod negate;
+pub mod signature;
 pub mod transactions;
 pub mod translate;
 

--- a/frost-bluepallas/src/signature.rs
+++ b/frost-bluepallas/src/signature.rs
@@ -1,0 +1,133 @@
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{BigInt, PrimeField};
+use frost_core::Signature;
+use mina_signer::PubKey;
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Serialize,
+};
+
+use crate::{errors::BluePallasError, transactions::Transaction, PallasPoseidon};
+
+pub struct Sig {
+    pub field: BigInt<4>,
+    pub scalar: BigInt<4>,
+}
+
+impl TryInto<Sig> for Signature<PallasPoseidon> {
+    type Error = BluePallasError;
+
+    fn try_into(self) -> Result<Sig, Self::Error> {
+        let x = self
+            .R()
+            .into_affine()
+            .x()
+            .ok_or_else(|| {
+                BluePallasError::InvalidSignature("Failed to convert x coordinate to bigint".into())
+            })?
+            .into_bigint();
+        let z = self.z().into_bigint();
+
+        Ok(Sig {
+            field: x,
+            scalar: z,
+        })
+    }
+}
+
+impl Serialize for Sig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("signature", 2)?;
+        state.serialize_field("field", &self.field.to_string())?;
+        state.serialize_field("scalar", &self.scalar.to_string())?;
+        state.end()
+    }
+}
+
+#[allow(non_snake_case)]
+pub struct PubKeySer {
+    pub pubKey: PubKey,
+}
+
+impl From<PubKey> for PubKeySer {
+    #[allow(non_snake_case)]
+    fn from(pubKey: PubKey) -> Self {
+        PubKeySer { pubKey }
+    }
+}
+
+impl Serialize for PubKeySer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("publicKey", 1)?;
+        state.serialize_field("address", &self.pubKey.into_address())?;
+        state.end()
+    }
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize)]
+pub struct TransactionSignature {
+    pub publicKey: PubKeySer,
+    pub signature: Sig,
+    pub payload: Transaction,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{helper, translate};
+    use mina_signer::Keypair;
+    use std::convert::TryInto;
+
+    #[test]
+    fn test_frost_sig_to_sig_conversion_matches_translate() -> Result<(), BluePallasError> {
+        // Generate a test signature using a known private key
+        let private_key_hex = "35dcca7620128d240cc3319c83dc6402ad439038361ba853af538a4cea3ddabc";
+        let mina_keypair = Keypair::from_hex(private_key_hex)
+            .map_err(|_| BluePallasError::InvalidSignature("Failed to parse keypair".into()))?;
+
+        let signing_key = translate::translate_minask(&mina_keypair)
+            .map_err(|_| BluePallasError::InvalidSignature("Failed to translate keypair".into()))?;
+
+        // Create a test message
+        let test_msg = b"test message for signature conversion";
+
+        // Generate FROST signature
+        let (frost_sig, _vk) =
+            helper::generate_signature_from_sk(test_msg, &signing_key, rand_core::OsRng).map_err(
+                |_| BluePallasError::InvalidSignature("Failed to generate signature".into()),
+            )?;
+
+        // Method 1: Existing translation approach
+        let mina_sig = translate::translate_sig(&frost_sig).map_err(|_| {
+            BluePallasError::InvalidSignature("Failed to translate signature".into())
+        })?;
+        let sig_base_existing: BigInt<4> = mina_sig.rx.into_bigint();
+        let sig_scalar_existing: BigInt<4> = mina_sig.s.into_bigint();
+        let existing_sig = Sig {
+            field: sig_base_existing,
+            scalar: sig_scalar_existing,
+        };
+
+        // Method 2: TryInto conversion
+        let tryinto_sig: Sig = frost_sig.try_into()?;
+
+        // Compare the results
+        assert_eq!(
+            existing_sig.field, tryinto_sig.field,
+            "Field components should match"
+        );
+        assert_eq!(
+            existing_sig.scalar, tryinto_sig.scalar,
+            "Scalar components should match"
+        );
+
+        Ok(())
+    }
+}

--- a/frost-bluepallas/src/signature.rs
+++ b/frost-bluepallas/src/signature.rs
@@ -7,7 +7,10 @@ use serde::{
     Serialize,
 };
 
-use crate::{errors::BluePallasError, transactions::Transaction, PallasPoseidon};
+use crate::{
+    errors::BluePallasError, transactions::Transaction, translate::translate_pk, PallasPoseidon,
+    VerifyingKey,
+};
 
 pub struct Sig {
     pub field: BigInt<4>,
@@ -56,6 +59,16 @@ impl From<PubKey> for PubKeySer {
     #[allow(non_snake_case)]
     fn from(pubKey: PubKey) -> Self {
         PubKeySer { pubKey }
+    }
+}
+
+impl TryFrom<VerifyingKey> for PubKeySer {
+    type Error = BluePallasError;
+
+    fn try_from(vk: VerifyingKey) -> Result<Self, Self::Error> {
+        translate_pk(&vk)
+            .map(|pub_key| PubKeySer { pubKey: pub_key })
+            .map_err(|e| BluePallasError::InvalidPublicKey(e.to_string()))
     }
 }
 

--- a/frost-client/examples/signing_example/signing_example.sh
+++ b/frost-client/examples/signing_example/signing_example.sh
@@ -173,7 +173,7 @@ cargo run --bin frost-client -- coordinator \
     --group "$GROUP_PUBLIC_KEY" \
     -S "$BOB_PUBLIC_KEY,$EVE_PUBLIC_KEY" \
     -m "$GENERATED_DIR/message.json" \
-    -o "$GENERATED_DIR/signature.hex" &
+    -o "$GENERATED_DIR/signature.json" &
 COORDINATOR_PID=$!
 
 # Wait for coordinator to start
@@ -236,11 +236,11 @@ if [ $COORDINATOR_EXIT -eq 0 ] && [ $BOB_EXIT -eq 0 ] && [ $EVE_EXIT -eq 0 ]; th
     echo "Original message: $TEST_MESSAGE"
     echo ""
 
-    if [ -f "$GENERATED_DIR/signature.hex" ]; then
-        SIGNATURE=$(cat "$GENERATED_DIR/signature.hex")
+    if [ -f "$GENERATED_DIR/signature.json" ]; then
+        SIGNATURE=$(cat "$GENERATED_DIR/signature.json")
         echo "Generated signature: $SIGNATURE"
         echo ""
-        echo "Signature saved to: $GENERATED_DIR/signature.hex"
+        echo "Signature saved to: $GENERATED_DIR/signature.json"
     else
         echo "⚠️  Signature file not found, but processes completed successfully."
     fi
@@ -255,7 +255,7 @@ if [ $COORDINATOR_EXIT -eq 0 ] && [ $BOB_EXIT -eq 0 ] && [ $EVE_EXIT -eq 0 ]; th
     echo ""
     echo "Files generated:"
     echo "  - $GENERATED_DIR/message.json (original message)"
-    echo "  - $GENERATED_DIR/signature.hex (FROST signature)"
+    echo "  - $GENERATED_DIR/signature.json (FROST signature)"
     echo "  - $GENERATED_DIR/alice.toml (Alice's config)"
     echo "  - $GENERATED_DIR/bob.toml (Bob's config)"
     echo "  - $GENERATED_DIR/eve.toml (Eve's config)"

--- a/frost-client/src/cli/args.rs
+++ b/frost-client/src/cli/args.rs
@@ -191,7 +191,7 @@ pub enum Command {
         #[arg(short = 'o', long, default_value = "")]
         signature: String,
         /// Network to use (testnet or mainnet)
-        #[arg(long, value_enum, default_value_t = Network::Testnet)]
+        #[arg(short = 'n', long, value_enum, default_value_t = Network::Testnet)]
         network: Network,
     },
     /// Participate in a FROST signing session.


### PR DESCRIPTION
This pull request modifies how frost-client outputs its signatures. Previously, frost-client was directly writing bytes as hex to stdout or as pure bytes to a file specified by the user.

Now the pull request outputs the whole transaction + signature in a json format e.g.
```json
{
  "publicKey": {
    "address": "B62qit6bC1oU5qhS9P1Jk3ED6s2jrUMMmHJZEVV9JQPi5cMxzg5reP1"
  },
  "signature": {
    "field": "8804473018225982236981733293095320552419768090456664704762763329916506705418",
    "scalar": "6760488178823721821174676859100747436164521187219139039837191703910687394970"
  },
  "payload": {
    "to": "B62qkcvM4DZE7k23ZHMLt1uaMVcixuxxuyz1XNJNCLkFbitDdUHxWs1",
    "from": "B62qkcvM4DZE7k23ZHMLt1uaMVcixuxxuyz1XNJNCLkFbitDdUHxWs1",
    "fee": "1000000000",
    "amount": "1000000000",
    "nonce": "1",
    "memo": "Hello Mina x FROST from the Rasp",
    "valid_until": "4294967295",
    "tag": [
      false,
      false,
      false
    ]
  }
}
```

The pr includes adding a new `signature.rs` file in bluepallas which is responsible for converting between possible different types to produce a transaction signature, along with extra error types and a modified `save_signature` function in frost-client/coordinator. 