### PR TITLE
feat: Added a feature guard for raw message fallback

### DIFF
--- a/frost-bluepallas/Cargo.toml
+++ b/frost-bluepallas/Cargo.toml
@@ -34,7 +34,7 @@ proptest = "1.6.0"
 rand_chacha = "0.3"
 bs58 = "0.5.1"
 reqwest = { workspace = true, features = ["blocking"] }
-mina-tx = { path = "../mina-tx", features = ["test-utils", "frost-bluepallas-compat"] }
+mina-tx = { path = "../mina-tx", features = ["test-utils", "frost-bluepallas-compat", "raw-message-fallback"] }
 # Use test-utils feature as dev dependency, this enables sharing test vectors
 # across unit tests and integration tests
 frost-bluepallas = { path = ".", features = ["test-utils"] }

--- a/mina-tx/Cargo.toml
+++ b/mina-tx/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static.workspace = true
 num-bigint = "0.4.6"
 
 [dev-dependencies]
-mina-tx = { path = ".", features = ["test-utils"] }
+mina-tx = { path = ".", features = ["test-utils", "raw-message-fallback"] }
 rand_chacha = "0.3"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 hex.workspace = true
@@ -34,3 +34,7 @@ default = []
 frost-bluepallas-compat = ["dep:frost-bluepallas", "dep:frost-core", "dep:ark-ec"]
 test-utils = []
 mesa-hardfork = []
+# Test/dev-only: re-enable the permissive `challenge()` fall-through that interprets
+# non-`PallasMessage` bytes as a raw Testnet/legacy message. Must NOT be enabled for
+# production builds — see `challenge()` in `pallas_message.rs`.
+raw-message-fallback = []

--- a/mina-tx/src/pallas_message.rs
+++ b/mina-tx/src/pallas_message.rs
@@ -287,9 +287,18 @@ impl frost_bluepallas::ChallengeMessage for PallasMessage {
             translate_pk(verifying_key).map_err(|_| frost_core::FieldError::MalformedScalar)?;
         let rx = r.into_affine().x;
 
-        // This fall-through into from_raw_bytes_default allows us to pass FROST tests which use arbitrary byte messages
+        // Malformed / non-`PallasMessage` inputs are rejected in normal builds so that a
+        // caller can never accidentally sign raw bytes under the Testnet/legacy defaults of
+        // `from_raw_bytes_default`. The permissive fall-through is compiled in only when the
+        // `raw-message-fallback` feature is enabled, which is done exclusively by test/dev
+        // builds so that frost-core's generic test harness (which signs fixed arbitrary byte
+        // strings) can still run.
+        #[cfg(feature = "raw-message-fallback")]
         let msg =
             Self::deserialize(message).unwrap_or_else(|_| Self::from_raw_bytes_default(message));
+        #[cfg(not(feature = "raw-message-fallback"))]
+        let msg =
+            Self::deserialize(message).map_err(|_| frost_core::FieldError::MalformedScalar)?;
         let network_id = msg.network_id();
         let is_legacy = msg.is_legacy();
 


### PR DESCRIPTION
Feature-guard the raw-byte challenge() fallback behind raw-message-fallback so production builds reject malformed/non-PallasMessage inputs (previously silently signed as Testnet/legacy) while tests keep the permissive path.

We couldn't use #[cfg(test)] because the tests needing the fallback live in other crates that compile mina-tx as a normal (non-test) dependency, so #[cfg(test)] would be inactive there. The feature is enabled only via dev-dependency edges, keeping it off in the real binary.

Ideally we remove this feature guard in the future, but that requires fixing many tests. I added an issue for this - #202